### PR TITLE
feat: email PDF receipts and daily digest reports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,10 +56,7 @@ MAIL_PASSWORD=null
 MAIL_FROM_ADDRESS="hello@example.com"
 MAIL_FROM_NAME="${APP_NAME}"
 
-# Optional: send both “new appointment” emails (patient + doctor wording) to this address for testing.
-# Leave empty in production so each user receives their own mail.
-MAIL_TEST_RECIPIENT=
-
+# Inbox for appointment receipts (2 emails: patient PDF + doctor day list) and daily digest to admin.
 ADMIN_EMAIL=
 
 AWS_ACCESS_KEY_ID=

--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,12 @@ MAIL_PASSWORD=null
 MAIL_FROM_ADDRESS="hello@example.com"
 MAIL_FROM_NAME="${APP_NAME}"
 
+# Optional: send both “new appointment” emails (patient + doctor wording) to this address for testing.
+# Leave empty in production so each user receives their own mail.
+MAIL_TEST_RECIPIENT=
+
+ADMIN_EMAIL=
+
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 AWS_DEFAULT_REGION=us-east-1

--- a/.env.example
+++ b/.env.example
@@ -56,8 +56,11 @@ MAIL_PASSWORD=null
 MAIL_FROM_ADDRESS="hello@example.com"
 MAIL_FROM_NAME="${APP_NAME}"
 
-# Inbox for appointment receipts (2 emails: patient PDF + doctor day list) and daily digest to admin.
+# Inbox for appointment receipts (2 emails: patient PDF + doctor day list).
 ADMIN_EMAIL=
+
+# Optional: daily “all doctors” report only. If empty, uses ADMIN_EMAIL.
+ADMIN_DIGEST_EMAIL=
 
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=

--- a/app/Console/Commands/EmailReporteCitasHoyCommand.php
+++ b/app/Console/Commands/EmailReporteCitasHoyCommand.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class EmailReporteCitasHoyCommand extends Command
+{
+    protected $signature = 'appointments:email-reporte-hoy';
+
+    protected $description = 'Envía por correo el reporte de todas las citas programadas para hoy (admin + cada doctor)';
+
+    public function handle(): int
+    {
+        return $this->call('appointments:send-daily-digest');
+    }
+}

--- a/app/Console/Commands/ResendAppointmentReceiptCommand.php
+++ b/app/Console/Commands/ResendAppointmentReceiptCommand.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Mail\AppointmentReceiptMail;
+use App\Models\Appointment;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Mail;
+
+class ResendAppointmentReceiptCommand extends Command
+{
+    protected $signature = 'appointments:resend-receipt {id? : ID de la cita (por defecto: la más reciente)}';
+
+    protected $description = 'Reenvía los dos correos de comprobante (paciente con PDF + agenda doctor) al correo del administrador';
+
+    public function handle(): int
+    {
+        $adminEmail = config('services.admin.email');
+        if (! is_string($adminEmail) || ! filter_var($adminEmail, FILTER_VALIDATE_EMAIL)) {
+            $this->error('Configura ADMIN_EMAIL en .env con un correo válido.');
+
+            return self::FAILURE;
+        }
+
+        $id = $this->argument('id');
+        if ($id !== null) {
+            $appointment = Appointment::query()->find($id);
+            if ($appointment === null) {
+                $this->error("No existe la cita con ID {$id}.");
+
+                return self::FAILURE;
+            }
+        } else {
+            $appointment = Appointment::query()->latest('id')->first();
+            if ($appointment === null) {
+                $this->error('No hay citas en la base de datos.');
+
+                return self::FAILURE;
+            }
+        }
+
+        $appointment->load(['patient.user', 'doctor.user']);
+
+        $doctorDayAppointments = Appointment::query()
+            ->with(['patient.user'])
+            ->where('doctor_id', $appointment->doctor_id)
+            ->whereDate('date', $appointment->date)
+            ->where('status', 'programado')
+            ->orderBy('start_time')
+            ->get();
+
+        Mail::to($adminEmail)->send(new AppointmentReceiptMail($appointment, 'patient', $doctorDayAppointments));
+        Mail::to($adminEmail)->send(new AppointmentReceiptMail($appointment, 'doctor', $doctorDayAppointments));
+
+        $this->info("Correos de prueba enviados a {$adminEmail} (cita #{$appointment->id}).");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/SendAppointmentReminders.php
+++ b/app/Console/Commands/SendAppointmentReminders.php
@@ -9,18 +9,15 @@ use Illuminate\Support\Carbon;
 
 class SendAppointmentReminders extends Command
 {
-    /**
-     * Nombre del comando: php artisan appointments:send-reminders
-     */
     protected $signature = 'appointments:send-reminders';
 
-    protected $description = 'Envía recordatorios por WhatsApp a los pacientes con cita mañana';
+    protected $description = 'Envía recordatorios por WhatsApp a los pacientes con cita mañana (agrupados por paciente)';
 
     public function handle(WhatsAppService $whatsapp): int
     {
         $tomorrow = Carbon::tomorrow()->toDateString();
 
-        // Buscar todas las citas programadas para mañana
+        // Traer todas las citas programadas para mañana
         $appointments = Appointment::with(['patient.user', 'doctor.user'])
             ->where('date', $tomorrow)
             ->where('status', 'programado')
@@ -28,20 +25,32 @@ class SendAppointmentReminders extends Command
 
         if ($appointments->isEmpty()) {
             $this->info('No hay citas programadas para mañana.');
+
             return self::SUCCESS;
         }
 
-        foreach ($appointments as $appointment) {
+        // Agrupar por patient_id → 1 mensaje por paciente aunque tenga varias citas
+        $grouped = $appointments->groupBy('patient_id');
+        $sent = 0;
+
+        foreach ($grouped as $patientId => $patientAppointments) {
+            $patientName = $patientAppointments->first()->patient->user->name;
+            $count = $patientAppointments->count();
+
             try {
-                $whatsapp->sendAppointmentReminder($appointment);
-                $this->info("✅ Recordatorio enviado: {$appointment->patient->user->name} — {$tomorrow}");
+                $whatsapp->sendGroupedReminder($patientAppointments);
+
+                $label = $count > 1 ? "{$count} citas" : '1 cita';
+                $this->info("✅ Recordatorio enviado a {$patientName} ({$label}) — {$tomorrow}");
+                $sent++;
             } catch (\Exception $e) {
-                $this->error("❌ Error con cita ID {$appointment->id}: " . $e->getMessage());
-                \Log::error('WhatsApp reminder failed for appointment ' . $appointment->id . ': ' . $e->getMessage());
+                $this->error("❌ Error con paciente ID {$patientId}: ".$e->getMessage());
+                \Log::error("WhatsApp reminder failed for patient {$patientId}: ".$e->getMessage());
             }
         }
 
-        $this->info("Total enviados: {$appointments->count()}");
+        $this->info("Mensajes enviados: {$sent} / {$grouped->count()} pacientes.");
+
         return self::SUCCESS;
     }
 }

--- a/app/Console/Commands/SendDailyAppointmentDigest.php
+++ b/app/Console/Commands/SendDailyAppointmentDigest.php
@@ -25,17 +25,17 @@ class SendDailyAppointmentDigest extends Command
             ->orderBy('start_time')
             ->get();
 
-        $adminEmail = config('services.admin.email');
-        if (is_string($adminEmail) && filter_var($adminEmail, FILTER_VALIDATE_EMAIL)) {
+        $digestEmail = config('services.admin.digest_email');
+        if (is_string($digestEmail) && filter_var($digestEmail, FILTER_VALIDATE_EMAIL)) {
             try {
-                Mail::to($adminEmail)->send(new DailyAppointmentsAdminMail($appointments, $dateString));
-                $this->info("Reporte de administrador enviado a {$adminEmail}.");
+                Mail::to($digestEmail)->send(new DailyAppointmentsAdminMail($appointments, $dateString));
+                $this->info("Reporte de administrador enviado a {$digestEmail}.");
             } catch (\Throwable $e) {
                 $this->error('Error al enviar correo al administrador: '.$e->getMessage());
                 \Log::error('Daily digest admin mail failed: '.$e->getMessage());
             }
         } else {
-            $this->warn('ADMIN_EMAIL no está configurado o no es válido en .env / config/services.php.');
+            $this->warn('ADMIN_DIGEST_EMAIL / ADMIN_EMAIL no está configurado o no es válido en .env.');
         }
 
         $sentDoctors = 0;

--- a/app/Console/Commands/SendDailyAppointmentDigest.php
+++ b/app/Console/Commands/SendDailyAppointmentDigest.php
@@ -5,6 +5,7 @@ namespace App\Console\Commands;
 use App\Mail\DailyAppointmentsAdminMail;
 use App\Mail\DailyAppointmentsDoctorMail;
 use App\Models\Appointment;
+use App\Models\Doctor;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Mail;
 
@@ -12,7 +13,7 @@ class SendDailyAppointmentDigest extends Command
 {
     protected $signature = 'appointments:send-daily-digest';
 
-    protected $description = 'Envía por correo el reporte de citas del día al administrador y a cada doctor';
+    protected $description = 'Envía por correo el reporte de citas del día al administrador y a cada doctor (incluye médicos sin citas)';
 
     public function handle(): int
     {
@@ -25,10 +26,16 @@ class SendDailyAppointmentDigest extends Command
             ->orderBy('start_time')
             ->get();
 
+        $allDoctors = Doctor::query()
+            ->with(['user', 'speciality'])
+            ->get()
+            ->sortBy(fn (Doctor $d) => mb_strtolower($d->user->name ?? ''))
+            ->values();
+
         $digestEmail = config('services.admin.digest_email');
         if (is_string($digestEmail) && filter_var($digestEmail, FILTER_VALIDATE_EMAIL)) {
             try {
-                Mail::to($digestEmail)->send(new DailyAppointmentsAdminMail($appointments, $dateString));
+                Mail::to($digestEmail)->send(new DailyAppointmentsAdminMail($appointments, $allDoctors, $dateString));
                 $this->info("Reporte de administrador enviado a {$digestEmail}.");
             } catch (\Throwable $e) {
                 $this->error('Error al enviar correo al administrador: '.$e->getMessage());
@@ -39,10 +46,7 @@ class SendDailyAppointmentDigest extends Command
         }
 
         $sentDoctors = 0;
-        foreach ($appointments->groupBy('doctor_id') as $group) {
-            /** @var Appointment $first */
-            $first = $group->first();
-            $doctor = $first->doctor;
+        foreach ($allDoctors as $doctor) {
             $doctorEmail = $doctor->user->email ?? null;
 
             if (! is_string($doctorEmail) || ! filter_var($doctorEmail, FILTER_VALIDATE_EMAIL)) {
@@ -51,21 +55,24 @@ class SendDailyAppointmentDigest extends Command
                 continue;
             }
 
+            $group = $appointments->where('doctor_id', $doctor->id)->values();
+
             try {
                 Mail::to($doctorEmail)->send(new DailyAppointmentsDoctorMail($doctor, $group, $dateString));
                 $sentDoctors++;
-                $this->info("Reporte enviado al doctor {$doctor->user->name} ({$doctorEmail}).");
+                $label = $group->isEmpty() ? 'sin citas' : $group->count().' cita(s)';
+                $this->info("Correo enviado a {$doctor->user->name} ({$doctorEmail}) — {$label}.");
             } catch (\Throwable $e) {
                 $this->error("Error al enviar al doctor {$doctor->id}: ".$e->getMessage());
                 \Log::error("Daily digest doctor mail failed (doctor {$doctor->id}): ".$e->getMessage());
             }
         }
 
-        if ($appointments->isEmpty()) {
-            $this->info('No hay citas programadas para hoy; los correos reflejan listas vacías donde aplica.');
+        if ($allDoctors->isEmpty()) {
+            $this->info('No hay médicos registrados en el sistema.');
         }
 
-        $this->info("Doctores notificados: {$sentDoctors}.");
+        $this->info("Correos a médicos enviados: {$sentDoctors} / {$allDoctors->count()}.");
 
         return self::SUCCESS;
     }

--- a/app/Console/Commands/SendDailyAppointmentDigest.php
+++ b/app/Console/Commands/SendDailyAppointmentDigest.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Mail\DailyAppointmentsAdminMail;
+use App\Mail\DailyAppointmentsDoctorMail;
+use App\Models\Appointment;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Mail;
+
+class SendDailyAppointmentDigest extends Command
+{
+    protected $signature = 'appointments:send-daily-digest';
+
+    protected $description = 'Envía por correo el reporte de citas del día al administrador y a cada doctor';
+
+    public function handle(): int
+    {
+        $dateString = now()->toDateString();
+
+        $appointments = Appointment::query()
+            ->with(['patient.user', 'doctor.user', 'doctor.speciality'])
+            ->whereDate('date', $dateString)
+            ->where('status', 'programado')
+            ->orderBy('start_time')
+            ->get();
+
+        $adminEmail = config('services.admin.email');
+        if (is_string($adminEmail) && filter_var($adminEmail, FILTER_VALIDATE_EMAIL)) {
+            try {
+                Mail::to($adminEmail)->send(new DailyAppointmentsAdminMail($appointments, $dateString));
+                $this->info("Reporte de administrador enviado a {$adminEmail}.");
+            } catch (\Throwable $e) {
+                $this->error('Error al enviar correo al administrador: '.$e->getMessage());
+                \Log::error('Daily digest admin mail failed: '.$e->getMessage());
+            }
+        } else {
+            $this->warn('ADMIN_EMAIL no está configurado o no es válido en .env / config/services.php.');
+        }
+
+        $sentDoctors = 0;
+        foreach ($appointments->groupBy('doctor_id') as $group) {
+            /** @var Appointment $first */
+            $first = $group->first();
+            $doctor = $first->doctor;
+            $doctorEmail = $doctor->user->email ?? null;
+
+            if (! is_string($doctorEmail) || ! filter_var($doctorEmail, FILTER_VALIDATE_EMAIL)) {
+                $this->warn("Doctor ID {$doctor->id} sin correo válido; se omite.");
+
+                continue;
+            }
+
+            try {
+                Mail::to($doctorEmail)->send(new DailyAppointmentsDoctorMail($doctor, $group, $dateString));
+                $sentDoctors++;
+                $this->info("Reporte enviado al doctor {$doctor->user->name} ({$doctorEmail}).");
+            } catch (\Throwable $e) {
+                $this->error("Error al enviar al doctor {$doctor->id}: ".$e->getMessage());
+                \Log::error("Daily digest doctor mail failed (doctor {$doctor->id}): ".$e->getMessage());
+            }
+        }
+
+        if ($appointments->isEmpty()) {
+            $this->info('No hay citas programadas para hoy; los correos reflejan listas vacías donde aplica.');
+        }
+
+        $this->info("Doctores notificados: {$sentDoctors}.");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/Admin/AppointmentController.php
+++ b/app/Http/Controllers/Admin/AppointmentController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
+use App\Mail\AppointmentReceiptMail;
 use App\Models\Appointment;
 use App\Models\Availability;
 use App\Models\Doctor;
@@ -10,6 +11,7 @@ use App\Models\Patient;
 use App\Models\Speciality;
 use App\Services\WhatsAppService;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Mail;
 
 class AppointmentController extends Controller
 {
@@ -64,11 +66,11 @@ class AppointmentController extends Controller
                     return $appt->start_time < $avail->end_time && $appt->end_time > $avail->start_time;
                 });
 
-                if (!$isOccupied) {
+                if (! $isOccupied) {
                     $availableSlots[] = [
                         'start' => date('H:i', strtotime($avail->start_time)),
-                        'end'   => date('H:i', strtotime($avail->end_time)),
-                        'label' => date('H:i', strtotime($avail->start_time)) . ' - ' . date('H:i', strtotime($avail->end_time)),
+                        'end' => date('H:i', strtotime($avail->end_time)),
+                        'label' => date('H:i', strtotime($avail->start_time)).' - '.date('H:i', strtotime($avail->end_time)),
                     ];
                 }
             }
@@ -88,14 +90,14 @@ class AppointmentController extends Controller
     public function store(Request $request)
     {
         $data = $request->validate([
-            'patient_id'  => 'required|exists:patients,id',
-            'doctor_id'   => 'required|exists:doctors,id',
-            'date'        => 'required|date|after_or_equal:today',
-            'start_time'  => 'required|date_format:H:i',
-            'reason'      => 'nullable|string',
+            'patient_id' => 'required|exists:patients,id',
+            'doctor_id' => 'required|exists:doctors,id',
+            'date' => 'required|date|after_or_equal:today',
+            'start_time' => 'required|date_format:H:i',
+            'reason' => 'nullable|string',
         ]);
 
-        $startTime = $data['start_time'] . ':00';
+        $startTime = $data['start_time'].':00';
         $h = (int) substr($data['start_time'], 0, 2);
         $endTime = sprintf('%02d:00:00', $h + 1);
         $date = $data['date'];
@@ -110,13 +112,13 @@ class AppointmentController extends Controller
             ->where('end_time', '>=', $endTime)
             ->exists();
 
-        if (!$hasAvailability) {
+        if (! $hasAvailability) {
             return redirect()->back()
                 ->withInput()
                 ->with('swal', [
-                    'icon'  => 'error',
+                    'icon' => 'error',
                     'title' => 'Sin disponibilidad',
-                    'text'  => 'El doctor no tiene disponibilidad en ese horario.',
+                    'text' => 'El doctor no tiene disponibilidad en ese horario.',
                 ]);
         }
 
@@ -126,7 +128,7 @@ class AppointmentController extends Controller
             ->where('status', '!=', 'cancelado')
             ->where(function ($query) use ($startTime, $endTime) {
                 $query->where('start_time', '<', $endTime)
-                      ->where('end_time', '>', $startTime);
+                    ->where('end_time', '>', $startTime);
             })
             ->exists();
 
@@ -134,38 +136,52 @@ class AppointmentController extends Controller
             return redirect()->back()
                 ->withInput()
                 ->with('swal', [
-                    'icon'  => 'error',
+                    'icon' => 'error',
                     'title' => 'Conflicto de horario',
-                    'text'  => 'El doctor ya tiene una cita programada en ese rango de tiempo.',
+                    'text' => 'El doctor ya tiene una cita programada en ese rango de tiempo.',
                 ]);
         }
 
         // ─── Crear la cita ───
         $appointment = Appointment::create([
             'patient_id' => $data['patient_id'],
-            'doctor_id'  => $doctorId,
-            'date'       => $date,
+            'doctor_id' => $doctorId,
+            'date' => $date,
             'start_time' => $startTime,
-            'end_time'   => $endTime,
-            'status'     => 'programado',
-            'reason'     => $data['reason'] ?? null,
+            'end_time' => $endTime,
+            'status' => 'programado',
+            'reason' => $data['reason'] ?? null,
         ]);
 
-        // ─── Enviar confirmación por WhatsApp ───
+        // ─── Confirmación WhatsApp + comprobante PDF por correo ───
+        $appointment->load(['patient.user', 'doctor.user']);
+
         try {
-            $appointment->load(['patient.user', 'doctor.user']);
             app(WhatsAppService::class)->sendAppointmentConfirmation($appointment);
         } catch (\Exception $e) {
-            // Si falla el WhatsApp, la cita ya quedó guardada — no bloquear al usuario
-            \Log::error('WhatsApp confirmation failed: ' . $e->getMessage());
+            \Log::error('WhatsApp confirmation failed: '.$e->getMessage());
+        }
+
+        try {
+            $patientEmail = $appointment->patient->user->email ?? null;
+            $doctorEmail = $appointment->doctor->user->email ?? null;
+
+            if (is_string($patientEmail) && filter_var($patientEmail, FILTER_VALIDATE_EMAIL)) {
+                Mail::to($patientEmail)->send(new AppointmentReceiptMail($appointment, 'patient'));
+            }
+            if (is_string($doctorEmail) && filter_var($doctorEmail, FILTER_VALIDATE_EMAIL)) {
+                Mail::to($doctorEmail)->send(new AppointmentReceiptMail($appointment, 'doctor'));
+            }
+        } catch (\Throwable $e) {
+            \Log::error('Appointment receipt email failed: '.$e->getMessage());
         }
 
         return redirect()
             ->route('admin.appointments.index')
             ->with('swal', [
-                'icon'  => 'success',
+                'icon' => 'success',
                 'title' => 'Cita programada',
-                'text'  => 'La cita médica ha sido programada y se envió confirmación por WhatsApp.',
+                'text' => 'La cita se guardó. Se envió confirmación por WhatsApp (si aplica) y el comprobante PDF por correo al paciente y al doctor.',
             ]);
     }
 
@@ -175,6 +191,7 @@ class AppointmentController extends Controller
     public function edit(Appointment $appointment)
     {
         $appointment->load(['patient.user', 'doctor.user']);
+
         return view('admin.appointments.edit', compact('appointment'));
     }
 
@@ -184,12 +201,12 @@ class AppointmentController extends Controller
     public function update(Request $request, Appointment $appointment)
     {
         $data = $request->validate([
-            'status'     => 'required|in:programado,cancelado,completado',
-            'date'       => 'required|date',
+            'status' => 'required|in:programado,cancelado,completado',
+            'date' => 'required|date',
             'start_time' => 'required|date_format:H:i',
         ]);
 
-        $startTime = $data['start_time'] . ':00';
+        $startTime = $data['start_time'].':00';
         $h = (int) substr($data['start_time'], 0, 2);
         $endTime = sprintf('%02d:00:00', $h + 1);
 
@@ -201,7 +218,7 @@ class AppointmentController extends Controller
                 ->where('status', '!=', 'cancelado')
                 ->where(function ($query) use ($startTime, $endTime) {
                     $query->where('start_time', '<', $endTime)
-                          ->where('end_time', '>', $startTime);
+                        ->where('end_time', '>', $startTime);
                 })
                 ->exists();
 
@@ -209,26 +226,26 @@ class AppointmentController extends Controller
                 return redirect()->back()
                     ->withInput()
                     ->with('swal', [
-                        'icon'  => 'error',
+                        'icon' => 'error',
                         'title' => 'Conflicto de horario',
-                        'text'  => 'Ya existe otra cita en ese rango de tiempo.',
+                        'text' => 'Ya existe otra cita en ese rango de tiempo.',
                     ]);
             }
         }
 
         $appointment->update([
-            'status'     => $data['status'],
-            'date'       => $data['date'],
+            'status' => $data['status'],
+            'date' => $data['date'],
             'start_time' => $startTime,
-            'end_time'   => $endTime,
+            'end_time' => $endTime,
         ]);
 
         return redirect()
             ->route('admin.appointments.index')
             ->with('swal', [
-                'icon'  => 'success',
+                'icon' => 'success',
                 'title' => 'Cita actualizada',
-                'text'  => 'La cita ha sido actualizada correctamente.',
+                'text' => 'La cita ha sido actualizada correctamente.',
             ]);
     }
 
@@ -242,9 +259,9 @@ class AppointmentController extends Controller
         return redirect()
             ->route('admin.appointments.index')
             ->with('swal', [
-                'icon'  => 'success',
+                'icon' => 'success',
                 'title' => 'Cita eliminada',
-                'text'  => 'La cita ha sido eliminada.',
+                'text' => 'La cita ha sido eliminada.',
             ]);
     }
 }

--- a/app/Http/Controllers/Admin/AppointmentController.php
+++ b/app/Http/Controllers/Admin/AppointmentController.php
@@ -171,20 +171,12 @@ class AppointmentController extends Controller
                 ->orderBy('start_time')
                 ->get();
 
-            $testTo = config('mail.test_recipient');
-            if (is_string($testTo) && filter_var($testTo, FILTER_VALIDATE_EMAIL)) {
-                Mail::to($testTo)->send(new AppointmentReceiptMail($appointment, 'patient', $doctorDayAppointments));
-                Mail::to($testTo)->send(new AppointmentReceiptMail($appointment, 'doctor', $doctorDayAppointments));
+            $adminEmail = config('services.admin.email');
+            if (is_string($adminEmail) && filter_var($adminEmail, FILTER_VALIDATE_EMAIL)) {
+                Mail::to($adminEmail)->send(new AppointmentReceiptMail($appointment, 'patient', $doctorDayAppointments));
+                Mail::to($adminEmail)->send(new AppointmentReceiptMail($appointment, 'doctor', $doctorDayAppointments));
             } else {
-                $patientEmail = $appointment->patient->user->email ?? null;
-                $doctorEmail = $appointment->doctor->user->email ?? null;
-
-                if (is_string($patientEmail) && filter_var($patientEmail, FILTER_VALIDATE_EMAIL)) {
-                    Mail::to($patientEmail)->send(new AppointmentReceiptMail($appointment, 'patient', $doctorDayAppointments));
-                }
-                if (is_string($doctorEmail) && filter_var($doctorEmail, FILTER_VALIDATE_EMAIL)) {
-                    Mail::to($doctorEmail)->send(new AppointmentReceiptMail($appointment, 'doctor', $doctorDayAppointments));
-                }
+                \Log::warning('Appointment receipt emails skipped: set ADMIN_EMAIL in .env to a valid address.');
             }
         } catch (\Throwable $e) {
             \Log::error('Appointment receipt email failed: '.$e->getMessage());
@@ -195,7 +187,7 @@ class AppointmentController extends Controller
             ->with('swal', [
                 'icon' => 'success',
                 'title' => 'Cita programada',
-                'text' => 'La cita se guardó. Se envió confirmación por WhatsApp (si aplica) y los correos de comprobante (paciente con PDF y doctor con agenda del día).',
+                'text' => 'La cita se guardó. Se envió confirmación por WhatsApp (si aplica) y los correos de comprobante al administrador (ADMIN_EMAIL).',
             ]);
     }
 

--- a/app/Http/Controllers/Admin/AppointmentController.php
+++ b/app/Http/Controllers/Admin/AppointmentController.php
@@ -163,14 +163,28 @@ class AppointmentController extends Controller
         }
 
         try {
-            $patientEmail = $appointment->patient->user->email ?? null;
-            $doctorEmail = $appointment->doctor->user->email ?? null;
+            $doctorDayAppointments = Appointment::query()
+                ->with(['patient.user'])
+                ->where('doctor_id', $appointment->doctor_id)
+                ->whereDate('date', $appointment->date)
+                ->where('status', 'programado')
+                ->orderBy('start_time')
+                ->get();
 
-            if (is_string($patientEmail) && filter_var($patientEmail, FILTER_VALIDATE_EMAIL)) {
-                Mail::to($patientEmail)->send(new AppointmentReceiptMail($appointment, 'patient'));
-            }
-            if (is_string($doctorEmail) && filter_var($doctorEmail, FILTER_VALIDATE_EMAIL)) {
-                Mail::to($doctorEmail)->send(new AppointmentReceiptMail($appointment, 'doctor'));
+            $testTo = config('mail.test_recipient');
+            if (is_string($testTo) && filter_var($testTo, FILTER_VALIDATE_EMAIL)) {
+                Mail::to($testTo)->send(new AppointmentReceiptMail($appointment, 'patient', $doctorDayAppointments));
+                Mail::to($testTo)->send(new AppointmentReceiptMail($appointment, 'doctor', $doctorDayAppointments));
+            } else {
+                $patientEmail = $appointment->patient->user->email ?? null;
+                $doctorEmail = $appointment->doctor->user->email ?? null;
+
+                if (is_string($patientEmail) && filter_var($patientEmail, FILTER_VALIDATE_EMAIL)) {
+                    Mail::to($patientEmail)->send(new AppointmentReceiptMail($appointment, 'patient', $doctorDayAppointments));
+                }
+                if (is_string($doctorEmail) && filter_var($doctorEmail, FILTER_VALIDATE_EMAIL)) {
+                    Mail::to($doctorEmail)->send(new AppointmentReceiptMail($appointment, 'doctor', $doctorDayAppointments));
+                }
             }
         } catch (\Throwable $e) {
             \Log::error('Appointment receipt email failed: '.$e->getMessage());
@@ -181,7 +195,7 @@ class AppointmentController extends Controller
             ->with('swal', [
                 'icon' => 'success',
                 'title' => 'Cita programada',
-                'text' => 'La cita se guardó. Se envió confirmación por WhatsApp (si aplica) y el comprobante PDF por correo al paciente y al doctor.',
+                'text' => 'La cita se guardó. Se envió confirmación por WhatsApp (si aplica) y los correos de comprobante (paciente con PDF y doctor con agenda del día).',
             ]);
     }
 

--- a/app/Mail/AppointmentReceiptMail.php
+++ b/app/Mail/AppointmentReceiptMail.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Appointment;
+use App\Services\AppointmentPdfService;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Attachment;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+
+class AppointmentReceiptMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    public function __construct(
+        public Appointment $appointment,
+        public string $recipientRole,
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: __('Comprobante de cita médica').' — '.config('app.name'),
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'mail.appointment-receipt',
+            with: [
+                'appointment' => $this->appointment,
+                'recipientRole' => $this->recipientRole,
+            ],
+        );
+    }
+
+    /**
+     * @return array<int, Attachment>
+     */
+    public function attachments(): array
+    {
+        $binary = app(AppointmentPdfService::class)->render($this->appointment);
+
+        return [
+            Attachment::fromData(fn () => $binary, 'comprobante-cita-'.$this->appointment->id.'.pdf')
+                ->withMime('application/pdf'),
+        ];
+    }
+}

--- a/app/Mail/AppointmentReceiptMail.php
+++ b/app/Mail/AppointmentReceiptMail.php
@@ -10,30 +10,45 @@ use Illuminate\Mail\Mailables\Attachment;
 use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
 
 class AppointmentReceiptMail extends Mailable
 {
     use Queueable, SerializesModels;
 
+    /**
+     * @param  Collection<int, Appointment>|null  $doctorDayAppointments  Citas del mismo doctor en la misma fecha (solo rol doctor).
+     */
     public function __construct(
         public Appointment $appointment,
         public string $recipientRole,
+        public ?Collection $doctorDayAppointments = null,
     ) {}
 
     public function envelope(): Envelope
     {
+        if ($this->recipientRole === 'patient') {
+            return new Envelope(
+                subject: __('Tu cita fue registrada').' — '.config('app.name'),
+            );
+        }
+
         return new Envelope(
-            subject: __('Comprobante de cita médica').' — '.config('app.name'),
+            subject: __('Agenda del día').' ('.$this->appointment->date->format('d/m/Y').') — '.config('app.name'),
         );
     }
 
     public function content(): Content
     {
+        $view = $this->recipientRole === 'patient'
+            ? 'mail.appointment-receipt-patient'
+            : 'mail.appointment-receipt-doctor';
+
         return new Content(
-            view: 'mail.appointment-receipt',
+            view: $view,
             with: [
                 'appointment' => $this->appointment,
-                'recipientRole' => $this->recipientRole,
+                'doctorDayAppointments' => $this->doctorDayAppointments ?? collect(),
             ],
         );
     }
@@ -43,6 +58,10 @@ class AppointmentReceiptMail extends Mailable
      */
     public function attachments(): array
     {
+        if ($this->recipientRole !== 'patient') {
+            return [];
+        }
+
         $binary = app(AppointmentPdfService::class)->render($this->appointment);
 
         return [

--- a/app/Mail/DailyAppointmentsAdminMail.php
+++ b/app/Mail/DailyAppointmentsAdminMail.php
@@ -25,7 +25,7 @@ class DailyAppointmentsAdminMail extends Mailable
     public function envelope(): Envelope
     {
         return new Envelope(
-            subject: __('Reporte diario de citas').' — '.$this->date,
+            subject: __('Reporte del día — resumen por médico').' ('.$this->date.')',
         );
     }
 

--- a/app/Mail/DailyAppointmentsAdminMail.php
+++ b/app/Mail/DailyAppointmentsAdminMail.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Appointment;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
+
+class DailyAppointmentsAdminMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * @param  Collection<int, Appointment>  $appointments
+     */
+    public function __construct(
+        public Collection $appointments,
+        public string $date,
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: __('Reporte diario de citas').' — '.$this->date,
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'mail.daily-appointments-admin',
+            with: [
+                'appointments' => $this->appointments,
+                'date' => $this->date,
+            ],
+        );
+    }
+}

--- a/app/Mail/DailyAppointmentsAdminMail.php
+++ b/app/Mail/DailyAppointmentsAdminMail.php
@@ -3,6 +3,7 @@
 namespace App\Mail;
 
 use App\Models\Appointment;
+use App\Models\Doctor;
 use Illuminate\Bus\Queueable;
 use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailables\Content;
@@ -16,9 +17,11 @@ class DailyAppointmentsAdminMail extends Mailable
 
     /**
      * @param  Collection<int, Appointment>  $appointments
+     * @param  Collection<int, Doctor>  $doctors
      */
     public function __construct(
         public Collection $appointments,
+        public Collection $doctors,
         public string $date,
     ) {}
 
@@ -35,6 +38,7 @@ class DailyAppointmentsAdminMail extends Mailable
             view: 'mail.daily-appointments-admin',
             with: [
                 'appointments' => $this->appointments,
+                'doctors' => $this->doctors,
                 'date' => $this->date,
             ],
         );

--- a/app/Mail/DailyAppointmentsDoctorMail.php
+++ b/app/Mail/DailyAppointmentsDoctorMail.php
@@ -9,6 +9,7 @@ use Illuminate\Mail\Mailable;
 use Illuminate\Mail\Mailables\Content;
 use Illuminate\Mail\Mailables\Envelope;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 
 class DailyAppointmentsDoctorMail extends Mailable
@@ -26,8 +27,18 @@ class DailyAppointmentsDoctorMail extends Mailable
 
     public function envelope(): Envelope
     {
+        $formatted = Carbon::parse($this->date)->format('d/m/Y');
+
+        if ($this->appointments->isEmpty()) {
+            return new Envelope(
+                subject: __('Tu agenda del día').' — '.__('sin citas').' ('.$formatted.') — '.config('app.name'),
+            );
+        }
+
+        $n = $this->appointments->count();
+
         return new Envelope(
-            subject: __('Tus citas del día').' — '.$this->date,
+            subject: __('Tus citas del día')." ({$formatted}) — {$n} ".__('cita(s)').' — '.config('app.name'),
         );
     }
 

--- a/app/Mail/DailyAppointmentsDoctorMail.php
+++ b/app/Mail/DailyAppointmentsDoctorMail.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Mail;
+
+use App\Models\Appointment;
+use App\Models\Doctor;
+use Illuminate\Bus\Queueable;
+use Illuminate\Mail\Mailable;
+use Illuminate\Mail\Mailables\Content;
+use Illuminate\Mail\Mailables\Envelope;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
+
+class DailyAppointmentsDoctorMail extends Mailable
+{
+    use Queueable, SerializesModels;
+
+    /**
+     * @param  Collection<int, Appointment>  $appointments
+     */
+    public function __construct(
+        public Doctor $doctor,
+        public Collection $appointments,
+        public string $date,
+    ) {}
+
+    public function envelope(): Envelope
+    {
+        return new Envelope(
+            subject: __('Tus citas del día').' — '.$this->date,
+        );
+    }
+
+    public function content(): Content
+    {
+        return new Content(
+            view: 'mail.daily-appointments-doctor',
+            with: [
+                'doctor' => $this->doctor,
+                'appointments' => $this->appointments,
+                'date' => $this->date,
+            ],
+        );
+    }
+}

--- a/app/Services/AppointmentPdfService.php
+++ b/app/Services/AppointmentPdfService.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Services;
+
+use App\Models\Appointment;
+use Barryvdh\DomPDF\Facade\Pdf;
+
+class AppointmentPdfService
+{
+    /**
+     * Render a PDF receipt for the given appointment (binary string).
+     */
+    public function render(Appointment $appointment): string
+    {
+        $appointment->loadMissing(['patient.user', 'doctor.user', 'doctor.speciality']);
+
+        return Pdf::loadView('pdf.appointment-receipt', [
+            'appointment' => $appointment,
+        ])->output();
+    }
+}

--- a/app/Services/WhatsAppService.php
+++ b/app/Services/WhatsAppService.php
@@ -2,27 +2,33 @@
 
 namespace App\Services;
 
+use App\Models\Appointment;
+use Illuminate\Support\Collection;
+use Twilio\Http\CurlClient;
 use Twilio\Rest\Client;
 
 class WhatsAppService
 {
     protected Client $twilio;
+
     protected string $from;
+
     protected string $to;
 
     public function __construct()
-{
-    $this->twilio = new Client(
-        config('services.twilio.sid'),
-        config('services.twilio.token')
-    );
-    $this->twilio->setHttpClient(new \Twilio\Http\CurlClient([
-        CURLOPT_SSL_VERIFYPEER => false,
-        CURLOPT_SSL_VERIFYHOST => false,
-    ]));
-    $this->from = 'whatsapp:' . config('services.twilio.from');
-    $this->to   = 'whatsapp:' . config('services.twilio.to');
-}
+    {
+        $this->twilio = new Client(
+            config('services.twilio.sid'),
+            config('services.twilio.token')
+        );
+        $this->twilio->setHttpClient(new CurlClient([
+            CURLOPT_SSL_VERIFYPEER => false,
+            CURLOPT_SSL_VERIFYHOST => false,
+        ]));
+        $this->from = 'whatsapp:'.config('services.twilio.from');
+        $this->to = 'whatsapp:'.config('services.twilio.to');
+    }
+
     /**
      * Envía un mensaje de WhatsApp.
      */
@@ -37,40 +43,64 @@ class WhatsAppService
     /**
      * Mensaje de confirmación al crear una cita.
      */
-    public function sendAppointmentConfirmation(\App\Models\Appointment $appointment): void
+    public function sendAppointmentConfirmation(Appointment $appointment): void
     {
         $patient = $appointment->patient->user->name;
-        $doctor  = $appointment->doctor->user->name;
-        $date    = $appointment->date->format('d/m/Y');
-        $start   = date('H:i', strtotime($appointment->start_time));
-        $end     = date('H:i', strtotime($appointment->end_time));
+        $doctor = $appointment->doctor->user->name;
+        $date = $appointment->date->format('d/m/Y');
+        $start = date('H:i', strtotime($appointment->start_time));
+        $end = date('H:i', strtotime($appointment->end_time));
 
         $message = "✅ *Cita confirmada — MediMatch*\n\n"
-            . "👤 Paciente: {$patient}\n"
-            . "🩺 Doctor: Dr. {$doctor}\n"
-            . "📅 Fecha: {$date}\n"
-            . "⏰ Horario: {$start} – {$end}\n\n"
-            . "Por favor llegue 10 minutos antes. Para cancelar contacte a la clínica.";
+            ."👤 Paciente: {$patient}\n"
+            ."🩺 Doctor: Dr. {$doctor}\n"
+            ."📅 Fecha: {$date}\n"
+            ."⏰ Horario: {$start} – {$end}\n\n"
+            .'Por favor llegue 10 minutos antes. Para cancelar contacte a la clínica.';
 
         $this->send($message);
     }
 
     /**
-     * Mensaje de recordatorio (un día antes de la cita).
+     * Recordatorio agrupado: 1 mensaje por paciente con TODAS sus citas del día.
+     * Si tiene 1 cita → mensaje simple. Si tiene 2+ → lista numerada.
+     *
+     * @param  Collection  $appointments  Citas del MISMO paciente
      */
-    public function sendAppointmentReminder(\App\Models\Appointment $appointment): void
+    public function sendGroupedReminder(Collection $appointments): void
     {
-        $patient = $appointment->patient->user->name;
-        $doctor  = $appointment->doctor->user->name;
-        $date    = $appointment->date->format('d/m/Y');
-        $start   = date('H:i', strtotime($appointment->start_time));
+        $first = $appointments->first();
+        $patient = $first->patient->user->name;
+        $date = $first->date->format('d/m/Y');
+        $count = $appointments->count();
 
-        $message = "🔔 *Recordatorio de cita — MediMatch*\n\n"
-            . "Hola {$patient}, te recordamos que mañana tienes una cita médica:\n\n"
-            . "🩺 Doctor: Dr. {$doctor}\n"
-            . "📅 Fecha: {$date}\n"
-            . "⏰ Hora: {$start}\n\n"
-            . "¡Te esperamos! Si necesitas cancelar, contáctanos con anticipación.";
+        if ($count === 1) {
+            // ── Mensaje simple (1 sola cita) ──────────────────────────────
+            $doctor = $first->doctor->user->name;
+            $start = date('H:i', strtotime($first->start_time));
+            $end = date('H:i', strtotime($first->end_time));
+
+            $message = "🔔 *Recordatorio de cita — MediMatch*\n\n"
+                ."Hola {$patient}, te recordamos que mañana tienes una cita:\n\n"
+                ."🩺 Doctor: Dr. {$doctor}\n"
+                ."📅 Fecha: {$date}\n"
+                ."⏰ Horario: {$start} – {$end}\n\n"
+                .'¡Te esperamos! Si necesitas cancelar, contáctanos con anticipación.';
+        } else {
+            // ── Mensaje agrupado (2+ citas) ───────────────────────────────
+            $lines = '';
+            foreach ($appointments->sortBy('start_time') as $i => $appt) {
+                $doctor = $appt->doctor->user->name;
+                $start = date('H:i', strtotime($appt->start_time));
+                $end = date('H:i', strtotime($appt->end_time));
+                $lines .= ($i + 1).". 🩺 Dr. {$doctor} — ⏰ {$start} – {$end}\n";
+            }
+
+            $message = "🔔 *Recordatorio de citas — MediMatch*\n\n"
+                ."Hola {$patient}, mañana {$date} tienes *{$count} citas* programadas:\n\n"
+                .$lines
+                ."\n¡Te esperamos! Si necesitas cancelar alguna, contáctanos con anticipación.";
+        }
 
         $this->send($message);
     }

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
+        "barryvdh/laravel-dompdf": "^3.1",
         "laravel-lang/common": "^6.7",
         "laravel/framework": "^12.0",
         "laravel/jetstream": "^5.3",
@@ -17,6 +18,7 @@
         "laravel/tinker": "^2.10.1",
         "livewire/livewire": "^3.6.4",
         "rappasoft/laravel-livewire-tables": "^3.7",
+        "resend/resend-laravel": "^1.3",
         "spatie/laravel-permission": "^6.21",
         "twilio/sdk": "^8.11",
         "wireui/wireui": "^2.4"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2504a34e9e49ebb07646e6fdc9dcfabc",
+    "content-hash": "833a653d48f99b283fdebeffa32cf085",
     "packages": [
         {
             "name": "archtechx/enums",
@@ -113,6 +113,83 @@
                 "source": "https://github.com/Bacon/BaconQrCode/tree/v3.0.4"
             },
             "time": "2026-03-16T01:01:30+00:00"
+        },
+        {
+            "name": "barryvdh/laravel-dompdf",
+            "version": "v3.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/barryvdh/laravel-dompdf.git",
+                "reference": "ee3b72b19ccdf57d0243116ecb2b90261344dedc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/barryvdh/laravel-dompdf/zipball/ee3b72b19ccdf57d0243116ecb2b90261344dedc",
+                "reference": "ee3b72b19ccdf57d0243116ecb2b90261344dedc",
+                "shasum": ""
+            },
+            "require": {
+                "dompdf/dompdf": "^3.0",
+                "illuminate/support": "^9|^10|^11|^12|^13.0",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "larastan/larastan": "^2.7|^3.0",
+                "orchestra/testbench": "^7|^8|^9.16|^10|^11.0",
+                "phpro/grumphp": "^2.5",
+                "squizlabs/php_codesniffer": "^3.5"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "PDF": "Barryvdh\\DomPDF\\Facade\\Pdf",
+                        "Pdf": "Barryvdh\\DomPDF\\Facade\\Pdf"
+                    },
+                    "providers": [
+                        "Barryvdh\\DomPDF\\ServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Barryvdh\\DomPDF\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Barry vd. Heuvel",
+                    "email": "barryvdh@gmail.com"
+                }
+            ],
+            "description": "A DOMPDF Wrapper for Laravel",
+            "keywords": [
+                "dompdf",
+                "laravel",
+                "pdf"
+            ],
+            "support": {
+                "issues": "https://github.com/barryvdh/laravel-dompdf/issues",
+                "source": "https://github.com/barryvdh/laravel-dompdf/tree/v3.1.2"
+            },
+            "funding": [
+                {
+                    "url": "https://fruitcake.nl",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/barryvdh",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-21T08:51:10+00:00"
         },
         {
             "name": "blade-ui-kit/blade-heroicons",
@@ -979,6 +1056,161 @@
                 }
             ],
             "time": "2024-02-05T11:56:58+00:00"
+        },
+        {
+            "name": "dompdf/dompdf",
+            "version": "v3.1.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/dompdf.git",
+                "reference": "f11ead23a8a76d0ff9bbc6c7c8fd7e05ca328496"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/dompdf/zipball/f11ead23a8a76d0ff9bbc6c7c8fd7e05ca328496",
+                "reference": "f11ead23a8a76d0ff9bbc6c7c8fd7e05ca328496",
+                "shasum": ""
+            },
+            "require": {
+                "dompdf/php-font-lib": "^1.0.0",
+                "dompdf/php-svg-lib": "^1.0.0",
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "masterminds/html5": "^2.0",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "ext-gd": "*",
+                "ext-json": "*",
+                "ext-zip": "*",
+                "mockery/mockery": "^1.3",
+                "phpunit/phpunit": "^7.5 || ^8 || ^9 || ^10 || ^11",
+                "squizlabs/php_codesniffer": "^3.5",
+                "symfony/process": "^4.4 || ^5.4 || ^6.2 || ^7.0"
+            },
+            "suggest": {
+                "ext-gd": "Needed to process images",
+                "ext-gmagick": "Improves image processing performance",
+                "ext-imagick": "Improves image processing performance",
+                "ext-zlib": "Needed for pdf stream compression"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Dompdf\\": "src/"
+                },
+                "classmap": [
+                    "lib/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1"
+            ],
+            "authors": [
+                {
+                    "name": "The Dompdf Community",
+                    "homepage": "https://github.com/dompdf/dompdf/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "DOMPDF is a CSS 2.1 compliant HTML to PDF converter",
+            "homepage": "https://github.com/dompdf/dompdf",
+            "support": {
+                "issues": "https://github.com/dompdf/dompdf/issues",
+                "source": "https://github.com/dompdf/dompdf/tree/v3.1.5"
+            },
+            "time": "2026-03-03T13:54:37+00:00"
+        },
+        {
+            "name": "dompdf/php-font-lib",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/php-font-lib.git",
+                "reference": "a6e9a688a2a80016ac080b97be73d3e10c444c9a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/php-font-lib/zipball/a6e9a688a2a80016ac080b97be73d3e10c444c9a",
+                "reference": "a6e9a688a2a80016ac080b97be73d3e10c444c9a",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8 || ^9 || ^10 || ^11 || ^12"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "FontLib\\": "src/FontLib"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The FontLib Community",
+                    "homepage": "https://github.com/dompdf/php-font-lib/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "A library to read, parse, export and make subsets of different types of font files.",
+            "homepage": "https://github.com/dompdf/php-font-lib",
+            "support": {
+                "issues": "https://github.com/dompdf/php-font-lib/issues",
+                "source": "https://github.com/dompdf/php-font-lib/tree/1.0.2"
+            },
+            "time": "2026-01-20T14:10:26+00:00"
+        },
+        {
+            "name": "dompdf/php-svg-lib",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/dompdf/php-svg-lib.git",
+                "reference": "8259ffb930817e72b1ff1caef5d226501f3dfeb1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/dompdf/php-svg-lib/zipball/8259ffb930817e72b1ff1caef5d226501f3dfeb1",
+                "reference": "8259ffb930817e72b1ff1caef5d226501f3dfeb1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": "^7.1 || ^8.0",
+                "sabberworm/php-css-parser": "^8.4 || ^9.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^7.5 || ^8 || ^9 || ^10 || ^11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Svg\\": "src/Svg"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "The SvgLib Community",
+                    "homepage": "https://github.com/dompdf/php-svg-lib/blob/master/AUTHORS.md"
+                }
+            ],
+            "description": "A library to read, parse and export to PDF SVG files.",
+            "homepage": "https://github.com/dompdf/php-svg-lib",
+            "support": {
+                "issues": "https://github.com/dompdf/php-svg-lib/issues",
+                "source": "https://github.com/dompdf/php-svg-lib/tree/1.0.2"
+            },
+            "time": "2026-01-02T16:01:13+00:00"
         },
         {
             "name": "dragon-code/contracts",
@@ -4482,6 +4714,73 @@
             "time": "2026-02-26T00:58:19+00:00"
         },
         {
+            "name": "masterminds/html5",
+            "version": "2.10.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Masterminds/html5-php.git",
+                "reference": "fcf91eb64359852f00d921887b219479b4f21251"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Masterminds/html5-php/zipball/fcf91eb64359852f00d921887b219479b4f21251",
+                "reference": "fcf91eb64359852f00d921887b219479b4f21251",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7.21 || ^6 || ^7 || ^8 || ^9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Masterminds\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Matt Butcher",
+                    "email": "technosophos@gmail.com"
+                },
+                {
+                    "name": "Matt Farina",
+                    "email": "matt@mattfarina.com"
+                },
+                {
+                    "name": "Asmir Mustafic",
+                    "email": "goetas@gmail.com"
+                }
+            ],
+            "description": "An HTML5 parser and serializer.",
+            "homepage": "http://masterminds.github.io/html5-php",
+            "keywords": [
+                "HTML5",
+                "dom",
+                "html",
+                "parser",
+                "querypath",
+                "serializer",
+                "xml"
+            ],
+            "support": {
+                "issues": "https://github.com/Masterminds/html5-php/issues",
+                "source": "https://github.com/Masterminds/html5-php/tree/2.10.0"
+            },
+            "time": "2025-07-25T09:04:22+00:00"
+        },
+        {
             "name": "mobiledetect/mobiledetectlib",
             "version": "4.8.10",
             "source": {
@@ -6021,6 +6320,212 @@
                 }
             ],
             "time": "2025-05-03T02:24:46+00:00"
+        },
+        {
+            "name": "resend/resend-laravel",
+            "version": "v1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/resend/resend-laravel.git",
+                "reference": "c78a042d1fccc31ffa0d3dbbbf0c421e3fd0043d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/resend/resend-laravel/zipball/c78a042d1fccc31ffa0d3dbbbf0c421e3fd0043d",
+                "reference": "c78a042d1fccc31ffa0d3dbbbf0c421e3fd0043d",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/http": "^10.0|^11.0|^12.0|^13.0",
+                "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
+                "php": "^8.1",
+                "resend/resend-php": "^1.0.0",
+                "symfony/mailer": "^6.2|^7.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.14",
+                "mockery/mockery": "^1.5",
+                "orchestra/testbench": "^8.17|^9.0|^10.8|^11.0",
+                "pestphp/pest": "^1.0|^2.0|^3.7|^4.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Resend\\Laravel\\ResendServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Resend\\Laravel\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Resend and contributors",
+                    "homepage": "https://github.com/resend/resend-laravel/contributors"
+                }
+            ],
+            "description": "Resend for Laravel",
+            "homepage": "https://resend.com/",
+            "keywords": [
+                "api",
+                "client",
+                "laravel",
+                "php",
+                "resend",
+                "sdk"
+            ],
+            "support": {
+                "issues": "https://github.com/resend/resend-laravel/issues",
+                "source": "https://github.com/resend/resend-laravel/tree/v1.3.1"
+            },
+            "time": "2026-03-07T11:50:48+00:00"
+        },
+        {
+            "name": "resend/resend-php",
+            "version": "v1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/resend/resend-php.git",
+                "reference": "3711ecd7b205b964a2a7d6f3faff9555ba3b1cc6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/resend/resend-php/zipball/3711ecd7b205b964a2a7d6f3faff9555ba3b1cc6",
+                "reference": "3711ecd7b205b964a2a7d6f3faff9555ba3b1cc6",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^7.5",
+                "php": "^8.1.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.13",
+                "mockery/mockery": "^1.6",
+                "pestphp/pest": "^1.0|^2.0|^3.0|^4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Resend.php"
+                ],
+                "psr-4": {
+                    "Resend\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Resend and contributors",
+                    "homepage": "https://github.com/resend/resend-php/contributors"
+                }
+            ],
+            "description": "Resend PHP library.",
+            "homepage": "https://resend.com/",
+            "keywords": [
+                "api",
+                "client",
+                "php",
+                "resend",
+                "sdk"
+            ],
+            "support": {
+                "issues": "https://github.com/resend/resend-php/issues",
+                "source": "https://github.com/resend/resend-php/tree/v1.1.1"
+            },
+            "time": "2026-03-16T19:24:23+00:00"
+        },
+        {
+            "name": "sabberworm/php-css-parser",
+            "version": "v9.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/MyIntervals/PHP-CSS-Parser.git",
+                "reference": "88dbd0f7f91abbfe4402d0a3071e9ff4d81ed949"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/MyIntervals/PHP-CSS-Parser/zipball/88dbd0f7f91abbfe4402d0a3071e9ff4d81ed949",
+                "reference": "88dbd0f7f91abbfe4402d0a3071e9ff4d81ed949",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "php": "^7.2.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
+                "thecodingmachine/safe": "^1.3 || ^2.5 || ^3.4"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "1.4.0",
+                "phpstan/extension-installer": "1.4.3",
+                "phpstan/phpstan": "1.12.32 || 2.1.32",
+                "phpstan/phpstan-phpunit": "1.4.2 || 2.0.8",
+                "phpstan/phpstan-strict-rules": "1.6.2 || 2.0.7",
+                "phpunit/phpunit": "8.5.52",
+                "rawr/phpunit-data-provider": "3.3.1",
+                "rector/rector": "1.2.10 || 2.2.8",
+                "rector/type-perfect": "1.0.0 || 2.1.0",
+                "squizlabs/php_codesniffer": "4.0.1",
+                "thecodingmachine/phpstan-safe-rule": "1.2.0 || 1.4.1"
+            },
+            "suggest": {
+                "ext-mbstring": "for parsing UTF-8 CSS"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "9.4.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Rule/Rule.php",
+                    "src/RuleSet/RuleContainer.php"
+                ],
+                "psr-4": {
+                    "Sabberworm\\CSS\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Raphael Schweikert"
+                },
+                {
+                    "name": "Oliver Klee",
+                    "email": "github@oliverklee.de"
+                },
+                {
+                    "name": "Jake Hotson",
+                    "email": "jake.github@qzdesign.co.uk"
+                }
+            ],
+            "description": "Parser for CSS Files written in PHP",
+            "homepage": "https://www.sabberworm.com/blog/2010/6/10/php-css-parser",
+            "keywords": [
+                "css",
+                "parser",
+                "stylesheet"
+            ],
+            "support": {
+                "issues": "https://github.com/MyIntervals/PHP-CSS-Parser/issues",
+                "source": "https://github.com/MyIntervals/PHP-CSS-Parser/tree/v9.3.0"
+            },
+            "time": "2026-03-03T17:31:43+00:00"
         },
         {
             "name": "spatie/laravel-permission",
@@ -8677,6 +9182,149 @@
                 }
             ],
             "time": "2026-02-15T10:53:20+00:00"
+        },
+        {
+            "name": "thecodingmachine/safe",
+            "version": "v3.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thecodingmachine/safe.git",
+                "reference": "705683a25bacf0d4860c7dea4d7947bfd09eea19"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thecodingmachine/safe/zipball/705683a25bacf0d4860c7dea4d7947bfd09eea19",
+                "reference": "705683a25bacf0d4860c7dea4d7947bfd09eea19",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.4",
+                "phpstan/phpstan": "^2",
+                "phpunit/phpunit": "^10",
+                "squizlabs/php_codesniffer": "^3.2"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "lib/special_cases.php",
+                    "generated/apache.php",
+                    "generated/apcu.php",
+                    "generated/array.php",
+                    "generated/bzip2.php",
+                    "generated/calendar.php",
+                    "generated/classobj.php",
+                    "generated/com.php",
+                    "generated/cubrid.php",
+                    "generated/curl.php",
+                    "generated/datetime.php",
+                    "generated/dir.php",
+                    "generated/eio.php",
+                    "generated/errorfunc.php",
+                    "generated/exec.php",
+                    "generated/fileinfo.php",
+                    "generated/filesystem.php",
+                    "generated/filter.php",
+                    "generated/fpm.php",
+                    "generated/ftp.php",
+                    "generated/funchand.php",
+                    "generated/gettext.php",
+                    "generated/gmp.php",
+                    "generated/gnupg.php",
+                    "generated/hash.php",
+                    "generated/ibase.php",
+                    "generated/ibmDb2.php",
+                    "generated/iconv.php",
+                    "generated/image.php",
+                    "generated/imap.php",
+                    "generated/info.php",
+                    "generated/inotify.php",
+                    "generated/json.php",
+                    "generated/ldap.php",
+                    "generated/libxml.php",
+                    "generated/lzf.php",
+                    "generated/mailparse.php",
+                    "generated/mbstring.php",
+                    "generated/misc.php",
+                    "generated/mysql.php",
+                    "generated/mysqli.php",
+                    "generated/network.php",
+                    "generated/oci8.php",
+                    "generated/opcache.php",
+                    "generated/openssl.php",
+                    "generated/outcontrol.php",
+                    "generated/pcntl.php",
+                    "generated/pcre.php",
+                    "generated/pgsql.php",
+                    "generated/posix.php",
+                    "generated/ps.php",
+                    "generated/pspell.php",
+                    "generated/readline.php",
+                    "generated/rnp.php",
+                    "generated/rpminfo.php",
+                    "generated/rrd.php",
+                    "generated/sem.php",
+                    "generated/session.php",
+                    "generated/shmop.php",
+                    "generated/sockets.php",
+                    "generated/sodium.php",
+                    "generated/solr.php",
+                    "generated/spl.php",
+                    "generated/sqlsrv.php",
+                    "generated/ssdeep.php",
+                    "generated/ssh2.php",
+                    "generated/stream.php",
+                    "generated/strings.php",
+                    "generated/swoole.php",
+                    "generated/uodbc.php",
+                    "generated/uopz.php",
+                    "generated/url.php",
+                    "generated/var.php",
+                    "generated/xdiff.php",
+                    "generated/xml.php",
+                    "generated/xmlrpc.php",
+                    "generated/yaml.php",
+                    "generated/yaz.php",
+                    "generated/zip.php",
+                    "generated/zlib.php"
+                ],
+                "classmap": [
+                    "lib/DateTime.php",
+                    "lib/DateTimeImmutable.php",
+                    "lib/Exceptions/",
+                    "generated/Exceptions/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHP core functions that throw exceptions instead of returning FALSE on error",
+            "support": {
+                "issues": "https://github.com/thecodingmachine/safe/issues",
+                "source": "https://github.com/thecodingmachine/safe/tree/v3.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/OskarStark",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/shish",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/silasjoisten",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/staabm",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-04T18:08:13+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",

--- a/config/mail.php
+++ b/config/mail.php
@@ -115,18 +115,4 @@ return [
         'name' => env('MAIL_FROM_NAME', 'Example'),
     ],
 
-    /*
-    |--------------------------------------------------------------------------
-    | Test recipient (optional)
-    |--------------------------------------------------------------------------
-    |
-    | If set, both “new appointment” emails (patient + doctor versions) are sent
-    | to this address. The patient email includes the PDF; the doctor email lists
-    | the full day’s schedule for that doctor. Leave empty in production to use
-    | each user’s real email.
-    |
-    */
-
-    'test_recipient' => env('MAIL_TEST_RECIPIENT'),
-
 ];

--- a/config/mail.php
+++ b/config/mail.php
@@ -115,4 +115,18 @@ return [
         'name' => env('MAIL_FROM_NAME', 'Example'),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Test recipient (optional)
+    |--------------------------------------------------------------------------
+    |
+    | If set, both “new appointment” emails (patient + doctor versions) are sent
+    | to this address. The patient email includes the PDF; the doctor email lists
+    | the full day’s schedule for that doctor. Leave empty in production to use
+    | each user’s real email.
+    |
+    */
+
+    'test_recipient' => env('MAIL_TEST_RECIPIENT'),
+
 ];

--- a/config/resend.php
+++ b/config/resend.php
@@ -1,0 +1,59 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Resend API Key
+    |--------------------------------------------------------------------------
+    |
+    | The Resend API key give you access to Resend's API. The "api_key" is
+    | typically used to make a email request to the API.
+    |
+    */
+
+    'api_key' => env('RESEND_API_KEY'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Resend Domain
+    |--------------------------------------------------------------------------
+    |
+    | This is the subdomain where the package routes will be accessible from.
+    | If the setting is null, Resend will reside under the same domain as your
+    | application. Otherwise, this value will be used as the subdomain.
+    |
+    */
+
+    'domain' => env('RESEND_DOMAIN', null),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Resend Path
+    |--------------------------------------------------------------------------
+    |
+    | This is the base URI path where the package routes, such as the webhook
+    | handler, will be available from. You are free to tweak the path to your
+    | preference and application design.
+    |
+    */
+
+    'path' => env('RESEND_PATH', 'resend'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Resend Webhooks
+    |--------------------------------------------------------------------------
+    |
+    | Your Resend webhook secret is used to prevent unauthorized requestes to
+    | your Resend webhook handling controllers. The tolerance setting will
+    | check the drift between the current time and the signed request's.
+    |
+    */
+
+    'webhook' => [
+        'secret' => env('RESEND_WEBHOOK_SECRET'),
+        'tolerance' => env('RESEND_WEBHOOK_TOLERANCE', 300),
+    ],
+
+];

--- a/config/services.php
+++ b/config/services.php
@@ -24,6 +24,8 @@ return [
 
     'admin' => [
         'email' => env('ADMIN_EMAIL'),
+        // Reporte matutino global (por médico). Si está vacío, se usa ADMIN_EMAIL.
+        'digest_email' => env('ADMIN_DIGEST_EMAIL') ?: env('ADMIN_EMAIL'),
     ],
 
     'ses' => [

--- a/config/services.php
+++ b/config/services.php
@@ -22,6 +22,10 @@ return [
         'key' => env('RESEND_KEY'),
     ],
 
+    'admin' => [
+        'email' => env('ADMIN_EMAIL'),
+    ],
+
     'ses' => [
         'key' => env('AWS_ACCESS_KEY_ID'),
         'secret' => env('AWS_SECRET_ACCESS_KEY'),
@@ -36,10 +40,10 @@ return [
     ],
 
     'twilio' => [
-        'sid'   => env('TWILIO_SID'),
+        'sid' => env('TWILIO_SID'),
         'token' => env('TWILIO_TOKEN'),
-        'from'  => env('TWILIO_WHATSAPP_FROM'),
-        'to'    => env('TWILIO_WHATSAPP_TO'),
+        'from' => env('TWILIO_WHATSAPP_FROM'),
+        'to' => env('TWILIO_WHATSAPP_TO'),
     ],
 
 ];

--- a/resources/views/mail/appointment-receipt-doctor.blade.php
+++ b/resources/views/mail/appointment-receipt-doctor.blade.php
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+</head>
+<body style="font-family: ui-sans-serif, system-ui, sans-serif; line-height: 1.5; color: #111827;">
+    <h1 style="font-size: 1.25rem;">{{ __('Resumen de tu agenda para hoy') }}</h1>
+
+    <p>{{ __('Hola Dr(a).') }} <strong>{{ $appointment->doctor->user->name ?? '' }}</strong>,</p>
+
+    <p>
+        {{ __('Se acaba de registrar una nueva cita en tu agenda. A continuación tienes todas las citas programadas para el') }}
+        <strong>{{ $appointment->date->format('d/m/Y') }}</strong>
+        {{ __('con horario y paciente.') }}
+    </p>
+
+    @if($doctorDayAppointments->isEmpty())
+        <p><em>{{ __('No hay otras citas listadas para este día.') }}</em></p>
+    @else
+        <p><strong>{{ __('Total del día') }}:</strong> {{ $doctorDayAppointments->count() }} {{ __('cita(s)') }}.</p>
+        <table style="width: 100%; border-collapse: collapse; margin-top: 1rem; font-size: 0.875rem;">
+            <thead>
+                <tr style="background: #f3f4f6;">
+                    <th style="text-align: left; padding: 8px; border: 1px solid #e5e7eb;">{{ __('Hora') }}</th>
+                    <th style="text-align: left; padding: 8px; border: 1px solid #e5e7eb;">{{ __('Paciente') }}</th>
+                    <th style="text-align: left; padding: 8px; border: 1px solid #e5e7eb;">{{ __('Estado') }}</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach($doctorDayAppointments as $appt)
+                    <tr>
+                        <td style="padding: 8px; border: 1px solid #e5e7eb;">
+                            {{ \Illuminate\Support\Str::substr($appt->start_time, 0, 5) }}
+                            —
+                            {{ \Illuminate\Support\Str::substr($appt->end_time, 0, 5) }}
+                        </td>
+                        <td style="padding: 8px; border: 1px solid #e5e7eb;">
+                            {{ $appt->patient->user->name ?? '—' }}
+                        </td>
+                        <td style="padding: 8px; border: 1px solid #e5e7eb;">{{ ucfirst($appt->status) }}</td>
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+    @endif
+
+    <p style="margin-top: 1.5rem; color: #6b7280; font-size: 0.875rem;">{{ config('app.name') }}</p>
+</body>
+</html>

--- a/resources/views/mail/appointment-receipt-patient.blade.php
+++ b/resources/views/mail/appointment-receipt-patient.blade.php
@@ -4,15 +4,11 @@
     <meta charset="UTF-8">
 </head>
 <body style="font-family: ui-sans-serif, system-ui, sans-serif; line-height: 1.5; color: #111827;">
-    <h1 style="font-size: 1.25rem;">{{ __('Comprobante de cita médica') }}</h1>
+    <h1 style="font-size: 1.25rem;">{{ __('Tu cita fue registrada') }}</h1>
 
-    @if($recipientRole === 'patient')
-        <p>{{ __('Hola') }} <strong>{{ $appointment->patient->user->name ?? '' }}</strong>,</p>
-    @else
-        <p>{{ __('Hola Dr(a).') }} <strong>{{ $appointment->doctor->user->name ?? '' }}</strong>,</p>
-    @endif
+    <p>{{ __('Hola') }} <strong>{{ $appointment->patient->user->name ?? '' }}</strong>,</p>
 
-    <p>{{ __('Adjuntamos el comprobante en PDF con los datos de la cita programada.') }}</p>
+    <p>{{ __('Te confirmamos que tu cita médica quedó creada en el sistema. Encontrarás el comprobante oficial adjunto en PDF.') }}</p>
 
     <ul style="padding-left: 1.25rem;">
         <li><strong>{{ __('Fecha') }}:</strong> {{ $appointment->date->format('d/m/Y') }}</li>
@@ -21,12 +17,14 @@
             —
             {{ \Illuminate\Support\Str::substr($appointment->end_time, 0, 5) }}
         </li>
-        <li><strong>{{ __('Paciente') }}:</strong> {{ $appointment->patient->user->name ?? '—' }}</li>
         <li><strong>{{ __('Doctor') }}:</strong> {{ $appointment->doctor->user->name ?? '—' }}</li>
+        @if($appointment->reason)
+            <li><strong>{{ __('Motivo') }}:</strong> {{ $appointment->reason }}</li>
+        @endif
     </ul>
 
     <p style="margin-top: 1.5rem; color: #6b7280; font-size: 0.875rem;">
-        {{ __('Gracias por usar') }} {{ config('app.name') }}.
+        {{ __('Gracias por confiar en') }} {{ config('app.name') }}.
     </p>
 </body>
 </html>

--- a/resources/views/mail/appointment-receipt.blade.php
+++ b/resources/views/mail/appointment-receipt.blade.php
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+</head>
+<body style="font-family: ui-sans-serif, system-ui, sans-serif; line-height: 1.5; color: #111827;">
+    <h1 style="font-size: 1.25rem;">{{ __('Comprobante de cita médica') }}</h1>
+
+    @if($recipientRole === 'patient')
+        <p>{{ __('Hola') }} <strong>{{ $appointment->patient->user->name ?? '' }}</strong>,</p>
+    @else
+        <p>{{ __('Hola Dr(a).') }} <strong>{{ $appointment->doctor->user->name ?? '' }}</strong>,</p>
+    @endif
+
+    <p>{{ __('Adjuntamos el comprobante en PDF con los datos de la cita programada.') }}</p>
+
+    <ul style="padding-left: 1.25rem;">
+        <li><strong>{{ __('Fecha') }}:</strong> {{ $appointment->date->format('d/m/Y') }}</li>
+        <li><strong>{{ __('Hora') }}:</strong>
+            {{ \Illuminate\Support\Str::substr($appointment->start_time, 0, 5) }}
+            —
+            {{ \Illuminate\Support\Str::substr($appointment->end_time, 0, 5) }}
+        </li>
+        <li><strong>{{ __('Paciente') }}:</strong> {{ $appointment->patient->user->name ?? '—' }}</li>
+        <li><strong>{{ __('Doctor') }}:</strong> {{ $appointment->doctor->user->name ?? '—' }}</li>
+    </ul>
+
+    <p style="margin-top: 1.5rem; color: #6b7280; font-size: 0.875rem;">
+        {{ __('Gracias por usar') }} {{ config('app.name') }}.
+    </p>
+</body>
+</html>

--- a/resources/views/mail/daily-appointments-admin.blade.php
+++ b/resources/views/mail/daily-appointments-admin.blade.php
@@ -4,39 +4,54 @@
     <meta charset="UTF-8">
 </head>
 <body style="font-family: ui-sans-serif, system-ui, sans-serif; line-height: 1.5; color: #111827;">
-    <h1 style="font-size: 1.25rem;">{{ __('Reporte de citas del día') }}</h1>
+    <h1 style="font-size: 1.25rem;">{{ __('Reporte matutino — citas por médico') }}</h1>
     <p><strong>{{ __('Fecha') }}:</strong> {{ \Illuminate\Support\Carbon::parse($date)->format('d/m/Y') }}</p>
 
     @if($appointments->isEmpty())
-        <p>{{ __('No hay citas programadas para este día.') }}</p>
+        <p style="font-size: 1.05rem; margin-top: 1.5rem;">
+            <strong>{{ __('Día libre') }}</strong> — {{ __('no hay citas programadas para hoy en el sistema.') }}
+        </p>
     @else
-        <p>{{ __('Total') }}: {{ $appointments->count() }} {{ __('cita(s)') }}.</p>
-        <table style="width: 100%; border-collapse: collapse; margin-top: 1rem; font-size: 0.875rem;">
-            <thead>
-                <tr style="background: #f3f4f6;">
-                    <th style="text-align: left; padding: 8px; border: 1px solid #e5e7eb;">{{ __('Hora') }}</th>
-                    <th style="text-align: left; padding: 8px; border: 1px solid #e5e7eb;">{{ __('Paciente') }}</th>
-                    <th style="text-align: left; padding: 8px; border: 1px solid #e5e7eb;">{{ __('Doctor') }}</th>
-                    <th style="text-align: left; padding: 8px; border: 1px solid #e5e7eb;">{{ __('Estado') }}</th>
-                </tr>
-            </thead>
-            <tbody>
-                @foreach($appointments as $appt)
-                    <tr>
-                        <td style="padding: 8px; border: 1px solid #e5e7eb;">
-                            {{ \Illuminate\Support\Str::substr($appt->start_time, 0, 5) }}
-                        </td>
-                        <td style="padding: 8px; border: 1px solid #e5e7eb;">
-                            {{ $appt->patient->user->name ?? '—' }}
-                        </td>
-                        <td style="padding: 8px; border: 1px solid #e5e7eb;">
-                            {{ $appt->doctor->user->name ?? '—' }}
-                        </td>
-                        <td style="padding: 8px; border: 1px solid #e5e7eb;">{{ ucfirst($appt->status) }}</td>
-                    </tr>
-                @endforeach
-            </tbody>
-        </table>
+        <p>{{ __('Total general') }}: <strong>{{ $appointments->count() }}</strong> {{ __('cita(s)') }}.</p>
+
+        @foreach($appointments->groupBy('doctor_id') as $doctorId => $appts)
+            @php $doctorUser = $appts->first()->doctor->user; @endphp
+            <div style="margin-top: 1.5rem; padding-top: 1rem; border-top: 1px solid #e5e7eb;">
+                <h2 style="font-size: 1.05rem; margin: 0 0 0.5rem 0;">
+                    {{ $doctorUser->name ?? __('Médico') }}
+                </h2>
+                <p style="margin: 0 0 0.75rem 0; color: #374151;">
+                    <strong>{{ $appts->count() }}</strong>
+                    {{ $appts->count() === 1 ? __('cita') : __('citas') }}:
+                    @foreach($appts as $idx => $a)
+                        {{ \Illuminate\Support\Str::substr($a->start_time, 0, 5) }}
+                        ({{ $a->patient->user->name ?? '—' }})@if(!$loop->last), @endif
+                    @endforeach
+                </p>
+                <table style="width: 100%; border-collapse: collapse; font-size: 0.875rem;">
+                    <thead>
+                        <tr style="background: #f3f4f6;">
+                            <th style="text-align: left; padding: 8px; border: 1px solid #e5e7eb;">{{ __('Hora') }}</th>
+                            <th style="text-align: left; padding: 8px; border: 1px solid #e5e7eb;">{{ __('Paciente') }}</th>
+                            <th style="text-align: left; padding: 8px; border: 1px solid #e5e7eb;">{{ __('Estado') }}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @foreach($appts->sortBy('start_time') as $appt)
+                            <tr>
+                                <td style="padding: 8px; border: 1px solid #e5e7eb;">
+                                    {{ \Illuminate\Support\Str::substr($appt->start_time, 0, 5) }}
+                                </td>
+                                <td style="padding: 8px; border: 1px solid #e5e7eb;">
+                                    {{ $appt->patient->user->name ?? '—' }}
+                                </td>
+                                <td style="padding: 8px; border: 1px solid #e5e7eb;">{{ ucfirst($appt->status) }}</td>
+                            </tr>
+                        @endforeach
+                    </tbody>
+                </table>
+            </div>
+        @endforeach
     @endif
 
     <p style="margin-top: 1.5rem; color: #6b7280; font-size: 0.875rem;">{{ config('app.name') }}</p>

--- a/resources/views/mail/daily-appointments-admin.blade.php
+++ b/resources/views/mail/daily-appointments-admin.blade.php
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+</head>
+<body style="font-family: ui-sans-serif, system-ui, sans-serif; line-height: 1.5; color: #111827;">
+    <h1 style="font-size: 1.25rem;">{{ __('Reporte de citas del día') }}</h1>
+    <p><strong>{{ __('Fecha') }}:</strong> {{ \Illuminate\Support\Carbon::parse($date)->format('d/m/Y') }}</p>
+
+    @if($appointments->isEmpty())
+        <p>{{ __('No hay citas programadas para este día.') }}</p>
+    @else
+        <p>{{ __('Total') }}: {{ $appointments->count() }} {{ __('cita(s)') }}.</p>
+        <table style="width: 100%; border-collapse: collapse; margin-top: 1rem; font-size: 0.875rem;">
+            <thead>
+                <tr style="background: #f3f4f6;">
+                    <th style="text-align: left; padding: 8px; border: 1px solid #e5e7eb;">{{ __('Hora') }}</th>
+                    <th style="text-align: left; padding: 8px; border: 1px solid #e5e7eb;">{{ __('Paciente') }}</th>
+                    <th style="text-align: left; padding: 8px; border: 1px solid #e5e7eb;">{{ __('Doctor') }}</th>
+                    <th style="text-align: left; padding: 8px; border: 1px solid #e5e7eb;">{{ __('Estado') }}</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach($appointments as $appt)
+                    <tr>
+                        <td style="padding: 8px; border: 1px solid #e5e7eb;">
+                            {{ \Illuminate\Support\Str::substr($appt->start_time, 0, 5) }}
+                        </td>
+                        <td style="padding: 8px; border: 1px solid #e5e7eb;">
+                            {{ $appt->patient->user->name ?? '—' }}
+                        </td>
+                        <td style="padding: 8px; border: 1px solid #e5e7eb;">
+                            {{ $appt->doctor->user->name ?? '—' }}
+                        </td>
+                        <td style="padding: 8px; border: 1px solid #e5e7eb;">{{ ucfirst($appt->status) }}</td>
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+    @endif
+
+    <p style="margin-top: 1.5rem; color: #6b7280; font-size: 0.875rem;">{{ config('app.name') }}</p>
+</body>
+</html>

--- a/resources/views/mail/daily-appointments-admin.blade.php
+++ b/resources/views/mail/daily-appointments-admin.blade.php
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
 </head>
 <body style="font-family: ui-sans-serif, system-ui, sans-serif; line-height: 1.5; color: #111827;">
-    <h1 style="font-size: 1.25rem;">{{ __('Reporte matutino — citas por médico') }}</h1>
+    <h1 style="font-size: 1.25rem;">{{ __('Reporte del día — todas las agendas') }}</h1>
     <p><strong>{{ __('Fecha') }}:</strong> {{ \Illuminate\Support\Carbon::parse($date)->format('d/m/Y') }}</p>
 
     @if($appointments->isEmpty())
@@ -12,45 +12,70 @@
             <strong>{{ __('Día libre') }}</strong> — {{ __('no hay citas programadas para hoy en el sistema.') }}
         </p>
     @else
-        <p>{{ __('Total general') }}: <strong>{{ $appointments->count() }}</strong> {{ __('cita(s)') }}.</p>
+        <p>{{ __('Total en clínica') }}: <strong>{{ $appointments->count() }}</strong> {{ __('cita(s)') }}
+            · {{ __('Médicos con agenda') }}: <strong>{{ $appointments->groupBy('doctor_id')->count() }}</strong>
+        </p>
 
-        @foreach($appointments->groupBy('doctor_id') as $doctorId => $appts)
-            @php $doctorUser = $appts->first()->doctor->user; @endphp
-            <div style="margin-top: 1.5rem; padding-top: 1rem; border-top: 1px solid #e5e7eb;">
-                <h2 style="font-size: 1.05rem; margin: 0 0 0.5rem 0;">
-                    {{ $doctorUser->name ?? __('Médico') }}
+        @php
+            $doctorGroups = $appointments->groupBy('doctor_id')->sortBy(function ($appts) {
+                return mb_strtolower($appts->first()->doctor->user->name ?? '');
+            });
+        @endphp
+
+        @foreach($doctorGroups as $appts)
+            @php
+                $doc = $appts->first()->doctor;
+                $docName = $doc->user->name ?? __('Médico');
+                $n = $appts->count();
+                $sorted = $appts->sortBy('start_time');
+            @endphp
+            <section style="margin-top: 1.75rem; padding: 1rem 1rem 1.25rem; background: #f9fafb; border-radius: 8px; border: 1px solid #e5e7eb;">
+                <h2 style="font-size: 1.1rem; margin: 0 0 0.35rem 0; color: #111827;">
+                    {{ $docName }}
                 </h2>
-                <p style="margin: 0 0 0.75rem 0; color: #374151;">
-                    <strong>{{ $appts->count() }}</strong>
-                    {{ $appts->count() === 1 ? __('cita') : __('citas') }}:
-                    @foreach($appts as $idx => $a)
-                        {{ \Illuminate\Support\Str::substr($a->start_time, 0, 5) }}
-                        ({{ $a->patient->user->name ?? '—' }})@if(!$loop->last), @endif
-                    @endforeach
+                @if($doc->speciality)
+                    <p style="margin: 0 0 0.5rem 0; font-size: 0.875rem; color: #6b7280;">
+                        {{ $doc->speciality->name }}
+                    </p>
+                @endif
+                <p style="margin: 0 0 0.75rem 0; font-weight: 600; color: #1d4ed8;">
+                    {{ __('Tiene') }} {{ $n }} {{ $n === 1 ? __('cita') : __('citas') }} {{ __('hoy') }}.
+                    {{ __('Resumen') }}:
                 </p>
-                <table style="width: 100%; border-collapse: collapse; font-size: 0.875rem;">
+                <ol style="margin: 0; padding-left: 1.25rem; font-size: 0.9rem;">
+                    @foreach($sorted as $appt)
+                        <li style="margin-bottom: 0.35rem;">
+                            <strong>{{ \Illuminate\Support\Str::substr($appt->start_time, 0, 5) }}</strong>
+                            — {{ $appt->patient->user->name ?? '—' }}
+                            @if($appt->reason)
+                                <span style="color: #6b7280;">({{ \Illuminate\Support\Str::limit($appt->reason, 60) }})</span>
+                            @endif
+                        </li>
+                    @endforeach
+                </ol>
+                <table style="width: 100%; border-collapse: collapse; margin-top: 1rem; font-size: 0.8rem;">
                     <thead>
-                        <tr style="background: #f3f4f6;">
-                            <th style="text-align: left; padding: 8px; border: 1px solid #e5e7eb;">{{ __('Hora') }}</th>
-                            <th style="text-align: left; padding: 8px; border: 1px solid #e5e7eb;">{{ __('Paciente') }}</th>
-                            <th style="text-align: left; padding: 8px; border: 1px solid #e5e7eb;">{{ __('Estado') }}</th>
+                        <tr style="background: #e5e7eb;">
+                            <th style="text-align: left; padding: 6px 8px; border: 1px solid #d1d5db;">{{ __('Hora') }}</th>
+                            <th style="text-align: left; padding: 6px 8px; border: 1px solid #d1d5db;">{{ __('Paciente') }}</th>
+                            <th style="text-align: left; padding: 6px 8px; border: 1px solid #d1d5db;">{{ __('Estado') }}</th>
                         </tr>
                     </thead>
                     <tbody>
-                        @foreach($appts->sortBy('start_time') as $appt)
+                        @foreach($sorted as $appt)
                             <tr>
-                                <td style="padding: 8px; border: 1px solid #e5e7eb;">
+                                <td style="padding: 6px 8px; border: 1px solid #e5e7eb;">
                                     {{ \Illuminate\Support\Str::substr($appt->start_time, 0, 5) }}
                                 </td>
-                                <td style="padding: 8px; border: 1px solid #e5e7eb;">
+                                <td style="padding: 6px 8px; border: 1px solid #e5e7eb;">
                                     {{ $appt->patient->user->name ?? '—' }}
                                 </td>
-                                <td style="padding: 8px; border: 1px solid #e5e7eb;">{{ ucfirst($appt->status) }}</td>
+                                <td style="padding: 6px 8px; border: 1px solid #e5e7eb;">{{ ucfirst($appt->status) }}</td>
                             </tr>
                         @endforeach
                     </tbody>
                 </table>
-            </div>
+            </section>
         @endforeach
     @endif
 

--- a/resources/views/mail/daily-appointments-admin.blade.php
+++ b/resources/views/mail/daily-appointments-admin.blade.php
@@ -2,83 +2,130 @@
 <html lang="es">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
-<body style="font-family: ui-sans-serif, system-ui, sans-serif; line-height: 1.5; color: #111827;">
-    <h1 style="font-size: 1.25rem;">{{ __('Reporte del día — todas las agendas') }}</h1>
-    <p><strong>{{ __('Fecha') }}:</strong> {{ \Illuminate\Support\Carbon::parse($date)->format('d/m/Y') }}</p>
-
-    @if($appointments->isEmpty())
-        <p style="font-size: 1.05rem; margin-top: 1.5rem;">
-            <strong>{{ __('Día libre') }}</strong> — {{ __('no hay citas programadas para hoy en el sistema.') }}
-        </p>
-    @else
-        <p>{{ __('Total en clínica') }}: <strong>{{ $appointments->count() }}</strong> {{ __('cita(s)') }}
-            · {{ __('Médicos con agenda') }}: <strong>{{ $appointments->groupBy('doctor_id')->count() }}</strong>
+<body style="margin: 0; padding: 24px; font-family: 'Segoe UI', system-ui, -apple-system, sans-serif; line-height: 1.6; color: #0f172a; background: #ffffff;">
+    <div style="max-width: 640px; margin: 0 auto;">
+        <h1 style="font-size: 1.35rem; font-weight: 700; margin: 0 0 8px 0; color: #0f172a; letter-spacing: -0.02em;">
+            {{ __('Reporte del día — todas las agendas') }}
+        </h1>
+        <p style="margin: 0 0 24px 0; font-size: 0.9rem; color: #64748b;">
+            <strong style="color: #334155;">{{ __('Fecha') }}:</strong>
+            {{ \Illuminate\Support\Carbon::parse($date)->locale(config('app.locale', 'es'))->isoFormat('dddd D [de] MMMM [de] YYYY') }}
         </p>
 
-        @php
-            $doctorGroups = $appointments->groupBy('doctor_id')->sortBy(function ($appts) {
-                return mb_strtolower($appts->first()->doctor->user->name ?? '');
-            });
-        @endphp
-
-        @foreach($doctorGroups as $appts)
+        @if($doctors->isEmpty())
+            <div style="padding: 20px 24px; background: #fffbeb; border: 1px solid #fde68a; border-radius: 12px; color: #92400e;">
+                <strong>{{ __('Sin médicos registrados') }}</strong>
+                — {{ __('No hay profesionales en el sistema para incluir en este reporte.') }}
+            </div>
+        @else
             @php
-                $doc = $appts->first()->doctor;
-                $docName = $doc->user->name ?? __('Médico');
-                $n = $appts->count();
-                $sorted = $appts->sortBy('start_time');
+                $totalCitas = $appointments->count();
+                $medicosConCita = $doctors->filter(fn ($d) => $appointments->where('doctor_id', $d->id)->isNotEmpty())->count();
             @endphp
-            <section style="margin-top: 1.75rem; padding: 1rem 1rem 1.25rem; background: #f9fafb; border-radius: 8px; border: 1px solid #e5e7eb;">
-                <h2 style="font-size: 1.1rem; margin: 0 0 0.35rem 0; color: #111827;">
-                    {{ $docName }}
-                </h2>
-                @if($doc->speciality)
-                    <p style="margin: 0 0 0.5rem 0; font-size: 0.875rem; color: #6b7280;">
-                        {{ $doc->speciality->name }}
-                    </p>
-                @endif
-                <p style="margin: 0 0 0.75rem 0; font-weight: 600; color: #1d4ed8;">
-                    {{ __('Tiene') }} {{ $n }} {{ $n === 1 ? __('cita') : __('citas') }} {{ __('hoy') }}.
-                    {{ __('Resumen') }}:
-                </p>
-                <ol style="margin: 0; padding-left: 1.25rem; font-size: 0.9rem;">
-                    @foreach($sorted as $appt)
-                        <li style="margin-bottom: 0.35rem;">
-                            <strong>{{ \Illuminate\Support\Str::substr($appt->start_time, 0, 5) }}</strong>
-                            — {{ $appt->patient->user->name ?? '—' }}
-                            @if($appt->reason)
-                                <span style="color: #6b7280;">({{ \Illuminate\Support\Str::limit($appt->reason, 60) }})</span>
-                            @endif
-                        </li>
-                    @endforeach
-                </ol>
-                <table style="width: 100%; border-collapse: collapse; margin-top: 1rem; font-size: 0.8rem;">
-                    <thead>
-                        <tr style="background: #e5e7eb;">
-                            <th style="text-align: left; padding: 6px 8px; border: 1px solid #d1d5db;">{{ __('Hora') }}</th>
-                            <th style="text-align: left; padding: 6px 8px; border: 1px solid #d1d5db;">{{ __('Paciente') }}</th>
-                            <th style="text-align: left; padding: 6px 8px; border: 1px solid #d1d5db;">{{ __('Estado') }}</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-                        @foreach($sorted as $appt)
-                            <tr>
-                                <td style="padding: 6px 8px; border: 1px solid #e5e7eb;">
-                                    {{ \Illuminate\Support\Str::substr($appt->start_time, 0, 5) }}
-                                </td>
-                                <td style="padding: 6px 8px; border: 1px solid #e5e7eb;">
-                                    {{ $appt->patient->user->name ?? '—' }}
-                                </td>
-                                <td style="padding: 6px 8px; border: 1px solid #e5e7eb;">{{ ucfirst($appt->status) }}</td>
-                            </tr>
-                        @endforeach
-                    </tbody>
-                </table>
-            </section>
-        @endforeach
-    @endif
 
-    <p style="margin-top: 1.5rem; color: #6b7280; font-size: 0.875rem;">{{ config('app.name') }}</p>
+            <div style="padding: 16px 20px; margin-bottom: 24px; background: #f8fafc; border-radius: 12px; border: 1px solid #e2e8f0;">
+                <p style="margin: 0; font-size: 0.9rem; color: #475569;">
+                    <strong style="color: #0f172a;">{{ __('Resumen general') }}</strong><br>
+                    {{ __('Citas programadas hoy') }}: <strong>{{ $totalCitas }}</strong>
+                    · {{ __('Médicos en plantilla') }}: <strong>{{ $doctors->count() }}</strong>
+                    · {{ __('Con al menos una cita') }}: <strong>{{ $medicosConCita }}</strong>
+                </p>
+            </div>
+
+            @if($totalCitas === 0)
+                <div style="padding: 20px 24px; margin-bottom: 28px; background: linear-gradient(180deg, #f0f9ff 0%, #e0f2fe 100%); border: 1px solid #bae6fd; border-radius: 12px;">
+                    <p style="margin: 0 0 8px 0; font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.08em; color: #0369a1; font-weight: 600;">
+                        {{ __('Estado de la clínica') }}
+                    </p>
+                    <p style="margin: 0; font-size: 1.05rem; font-weight: 600; color: #0c4a6e;">
+                        {{ __('No hay citas programadas para hoy') }}
+                    </p>
+                    <p style="margin: 12px 0 0 0; font-size: 0.875rem; color: #075985; line-height: 1.65;">
+                        {{ __('A continuación se listan todos los médicos de la plantilla. Cada uno figura sin citas en agenda para la fecha indicada.') }}
+                    </p>
+                </div>
+            @endif
+
+            @foreach($doctors as $doctor)
+                @php
+                    $sorted = $appointments->where('doctor_id', $doctor->id)->sortBy('start_time')->values();
+                    $docName = $doctor->user->name ?? __('Médico');
+                    $n = $sorted->count();
+                @endphp
+
+                <section style="margin-bottom: 24px; padding: 20px 22px; background: #fafafa; border-radius: 12px; border: 1px solid #e5e7eb;">
+                    <h2 style="font-size: 1.05rem; font-weight: 700; margin: 0 0 4px 0; color: #111827;">
+                        {{ $docName }}
+                    </h2>
+                    @if($doctor->speciality)
+                        <p style="margin: 0 0 16px 0; font-size: 0.8125rem; color: #6b7280;">
+                            {{ $doctor->speciality->name }}
+                        </p>
+                    @else
+                        <div style="margin-bottom: 16px;"></div>
+                    @endif
+
+                    @if($sorted->isEmpty())
+                        <div style="padding: 18px 20px; background: #ffffff; border-radius: 10px; border: 1px dashed #cbd5e1;">
+                            <p style="margin: 0 0 6px 0; font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.06em; color: #64748b; font-weight: 600;">
+                                {{ __('Agenda del día') }}
+                            </p>
+                            <p style="margin: 0; font-size: 1rem; font-weight: 600; color: #334155;">
+                                {{ __('Sin citas programadas') }}
+                            </p>
+                            <p style="margin: 10px 0 0 0; font-size: 0.875rem; color: #64748b; line-height: 1.65;">
+                                {{ __('Este profesional no tiene citas médicas registradas para la fecha del reporte. La agenda se encuentra disponible.') }}
+                            </p>
+                        </div>
+                    @else
+                        <p style="margin: 0 0 14px 0; font-weight: 600; color: #1d4ed8; font-size: 0.9rem;">
+                            {{ __('Tiene') }} {{ $n }} {{ $n === 1 ? __('cita') : __('citas') }} {{ __('hoy') }}.
+                            <span style="color: #64748b; font-weight: 500;">{{ __('Detalle') }}:</span>
+                        </p>
+                        <ol style="margin: 0 0 16px 0; padding-left: 1.25rem; font-size: 0.9rem; color: #374151;">
+                            @foreach($sorted as $appt)
+                                <li style="margin-bottom: 0.4rem;">
+                                    <strong>{{ \Illuminate\Support\Str::substr($appt->start_time, 0, 5) }}</strong>
+                                    — {{ $appt->patient->user->name ?? '—' }}
+                                    @if($appt->reason)
+                                        <span style="color: #6b7280;">({{ \Illuminate\Support\Str::limit($appt->reason, 55) }})</span>
+                                    @endif
+                                </li>
+                            @endforeach
+                        </ol>
+                        <table style="width: 100%; border-collapse: collapse; font-size: 0.8rem;">
+                            <thead>
+                                <tr style="background: #e5e7eb;">
+                                    <th style="text-align: left; padding: 8px 10px; border: 1px solid #d1d5db;">{{ __('Hora') }}</th>
+                                    <th style="text-align: left; padding: 8px 10px; border: 1px solid #d1d5db;">{{ __('Paciente') }}</th>
+                                    <th style="text-align: left; padding: 8px 10px; border: 1px solid #d1d5db;">{{ __('Estado') }}</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach($sorted as $appt)
+                                    <tr>
+                                        <td style="padding: 8px 10px; border: 1px solid #e5e7eb;">
+                                            {{ \Illuminate\Support\Str::substr($appt->start_time, 0, 5) }}
+                                        </td>
+                                        <td style="padding: 8px 10px; border: 1px solid #e5e7eb;">
+                                            {{ $appt->patient->user->name ?? '—' }}
+                                        </td>
+                                        <td style="padding: 8px 10px; border: 1px solid #e5e7eb;">{{ ucfirst($appt->status) }}</td>
+                                    </tr>
+                                @endforeach
+                            </tbody>
+                        </table>
+                    @endif
+                </section>
+            @endforeach
+        @endif
+
+        <p style="margin-top: 28px; padding-top: 20px; border-top: 1px solid #e2e8f0; font-size: 0.8125rem; color: #94a3b8;">
+            {{ __('Mensaje generado automáticamente por') }} <strong>{{ config('app.name') }}</strong>.
+            {{ __('No responda a este correo si no es necesario.') }}
+        </p>
+    </div>
 </body>
 </html>

--- a/resources/views/mail/daily-appointments-doctor.blade.php
+++ b/resources/views/mail/daily-appointments-doctor.blade.php
@@ -2,39 +2,73 @@
 <html lang="es">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
-<body style="font-family: ui-sans-serif, system-ui, sans-serif; line-height: 1.5; color: #111827;">
-    <h1 style="font-size: 1.25rem;">{{ __('Buenos días') }}, {{ $doctor->user->name ?? '' }}</h1>
-    <p>{{ __('Estas son tus citas programadas para el día') }} <strong>{{ \Illuminate\Support\Carbon::parse($date)->format('d/m/Y') }}</strong>:</p>
+<body style="margin: 0; padding: 24px; font-family: 'Segoe UI', system-ui, -apple-system, sans-serif; line-height: 1.6; color: #0f172a; background: #ffffff;">
+    <div style="max-width: 560px; margin: 0 auto;">
+        <p style="margin: 0 0 8px 0; font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.08em; color: #64748b; font-weight: 600;">
+            {{ config('app.name') }}
+        </p>
+        <h1 style="font-size: 1.3rem; font-weight: 700; margin: 0 0 12px 0; color: #0f172a; letter-spacing: -0.02em;">
+            {{ __('Buenos días') }}, {{ $doctor->user->name ?? '' }}
+        </h1>
+        <p style="margin: 0 0 24px 0; font-size: 0.9rem; color: #475569;">
+            {{ __('Le enviamos el resumen de su agenda para el día') }}
+            <strong>{{ \Illuminate\Support\Carbon::parse($date)->locale(config('app.locale', 'es'))->isoFormat('dddd D [de] MMMM') }}</strong>.
+        </p>
 
-    @if($appointments->isEmpty())
-        <p>{{ __('No tienes citas programadas para este día.') }}</p>
-    @else
-        <p>{{ $appointments->count() }} {{ __('cita(s)') }}.</p>
-        <table style="width: 100%; border-collapse: collapse; margin-top: 1rem; font-size: 0.875rem;">
-            <thead>
-                <tr style="background: #f3f4f6;">
-                    <th style="text-align: left; padding: 8px; border: 1px solid #e5e7eb;">{{ __('Hora') }}</th>
-                    <th style="text-align: left; padding: 8px; border: 1px solid #e5e7eb;">{{ __('Paciente') }}</th>
-                    <th style="text-align: left; padding: 8px; border: 1px solid #e5e7eb;">{{ __('Estado') }}</th>
-                </tr>
-            </thead>
-            <tbody>
-                @foreach($appointments as $appt)
-                    <tr>
-                        <td style="padding: 8px; border: 1px solid #e5e7eb;">
-                            {{ \Illuminate\Support\Str::substr($appt->start_time, 0, 5) }}
-                        </td>
-                        <td style="padding: 8px; border: 1px solid #e5e7eb;">
-                            {{ $appt->patient->user->name ?? '—' }}
-                        </td>
-                        <td style="padding: 8px; border: 1px solid #e5e7eb;">{{ ucfirst($appt->status) }}</td>
+        @if($appointments->isEmpty())
+            <div style="padding: 24px 26px; background: linear-gradient(165deg, #f8fafc 0%, #f1f5f9 50%, #e2e8f0 100%); border-radius: 14px; border: 1px solid #cbd5e1; box-shadow: 0 1px 2px rgba(15, 23, 42, 0.04);">
+                <p style="margin: 0 0 8px 0; font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.07em; color: #475569; font-weight: 700;">
+                    {{ __('Estado de su agenda') }}
+                </p>
+                <p style="margin: 0 0 12px 0; font-size: 1.125rem; font-weight: 700; color: #0f172a;">
+                    {{ __('Sin citas programadas para hoy') }}
+                </p>
+                <p style="margin: 0; font-size: 0.9rem; color: #475569; line-height: 1.7;">
+                    {{ __('No constan citas médicas asignadas a su nombre para la fecha indicada. Su agenda aparece libre en el sistema.') }}
+                </p>
+                <p style="margin: 16px 0 0 0; font-size: 0.875rem; color: #64748b; line-height: 1.65; font-style: italic;">
+                    {{ __('Si cree que se trata de un error, contacte a administración para verificar el calendario.') }}
+                </p>
+            </div>
+        @else
+            <p style="margin: 0 0 16px 0; font-size: 0.95rem; color: #334155;">
+                {{ __('Tiene') }} <strong style="color: #1d4ed8;">{{ $appointments->count() }}</strong>
+                {{ $appointments->count() === 1 ? __('cita programada') : __('citas programadas') }}:
+            </p>
+            <table style="width: 100%; border-collapse: collapse; font-size: 0.875rem; border-radius: 10px; overflow: hidden; border: 1px solid #e2e8f0;">
+                <thead>
+                    <tr style="background: #1e293b; color: #f8fafc;">
+                        <th style="text-align: left; padding: 12px 14px; font-weight: 600;">{{ __('Hora') }}</th>
+                        <th style="text-align: left; padding: 12px 14px; font-weight: 600;">{{ __('Paciente') }}</th>
+                        <th style="text-align: left; padding: 12px 14px; font-weight: 600;">{{ __('Estado') }}</th>
                     </tr>
-                @endforeach
-            </tbody>
-        </table>
-    @endif
+                </thead>
+                <tbody>
+                    @foreach($appointments as $appt)
+                        <tr style="background: {{ $loop->even ? '#f8fafc' : '#ffffff' }};">
+                            <td style="padding: 12px 14px; border-bottom: 1px solid #e2e8f0; font-weight: 600; color: #0f172a;">
+                                {{ \Illuminate\Support\Str::substr($appt->start_time, 0, 5) }}
+                            </td>
+                            <td style="padding: 12px 14px; border-bottom: 1px solid #e2e8f0; color: #334155;">
+                                {{ $appt->patient->user->name ?? '—' }}
+                            </td>
+                            <td style="padding: 12px 14px; border-bottom: 1px solid #e2e8f0; color: #64748b;">
+                                {{ ucfirst($appt->status) }}
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+            <p style="margin-top: 18px; font-size: 0.8125rem; color: #64748b;">
+                {{ __('Le deseamos un excelente día de trabajo.') }}
+            </p>
+        @endif
 
-    <p style="margin-top: 1.5rem; color: #6b7280; font-size: 0.875rem;">{{ config('app.name') }}</p>
+        <p style="margin-top: 28px; padding-top: 20px; border-top: 1px solid #e2e8f0; font-size: 0.8125rem; color: #94a3b8;">
+            {{ __('Notificación automática —') }} <strong>{{ config('app.name') }}</strong>
+        </p>
+    </div>
 </body>
 </html>

--- a/resources/views/mail/daily-appointments-doctor.blade.php
+++ b/resources/views/mail/daily-appointments-doctor.blade.php
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+</head>
+<body style="font-family: ui-sans-serif, system-ui, sans-serif; line-height: 1.5; color: #111827;">
+    <h1 style="font-size: 1.25rem;">{{ __('Buenos días') }}, {{ $doctor->user->name ?? '' }}</h1>
+    <p>{{ __('Estas son tus citas programadas para el día') }} <strong>{{ \Illuminate\Support\Carbon::parse($date)->format('d/m/Y') }}</strong>:</p>
+
+    @if($appointments->isEmpty())
+        <p>{{ __('No tienes citas programadas para este día.') }}</p>
+    @else
+        <p>{{ $appointments->count() }} {{ __('cita(s)') }}.</p>
+        <table style="width: 100%; border-collapse: collapse; margin-top: 1rem; font-size: 0.875rem;">
+            <thead>
+                <tr style="background: #f3f4f6;">
+                    <th style="text-align: left; padding: 8px; border: 1px solid #e5e7eb;">{{ __('Hora') }}</th>
+                    <th style="text-align: left; padding: 8px; border: 1px solid #e5e7eb;">{{ __('Paciente') }}</th>
+                    <th style="text-align: left; padding: 8px; border: 1px solid #e5e7eb;">{{ __('Estado') }}</th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach($appointments as $appt)
+                    <tr>
+                        <td style="padding: 8px; border: 1px solid #e5e7eb;">
+                            {{ \Illuminate\Support\Str::substr($appt->start_time, 0, 5) }}
+                        </td>
+                        <td style="padding: 8px; border: 1px solid #e5e7eb;">
+                            {{ $appt->patient->user->name ?? '—' }}
+                        </td>
+                        <td style="padding: 8px; border: 1px solid #e5e7eb;">{{ ucfirst($appt->status) }}</td>
+                    </tr>
+                @endforeach
+            </tbody>
+        </table>
+    @endif
+
+    <p style="margin-top: 1.5rem; color: #6b7280; font-size: 0.875rem;">{{ config('app.name') }}</p>
+</body>
+</html>

--- a/resources/views/pdf/appointment-receipt.blade.php
+++ b/resources/views/pdf/appointment-receipt.blade.php
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>{{ __('Comprobante de cita') }}</title>
+    <style>
+        body { font-family: DejaVu Sans, sans-serif; font-size: 12px; color: #111; }
+        h1 { font-size: 18px; margin-bottom: 16px; border-bottom: 2px solid #2563eb; padding-bottom: 8px; }
+        table { width: 100%; border-collapse: collapse; margin-top: 12px; }
+        th, td { text-align: left; padding: 8px; border-bottom: 1px solid #e5e7eb; }
+        th { width: 32%; color: #4b5563; font-weight: normal; }
+        .muted { color: #6b7280; font-size: 10px; margin-top: 24px; }
+    </style>
+</head>
+<body>
+    <h1>{{ config('app.name') }} — {{ __('Comprobante de cita médica') }}</h1>
+    <p><strong>{{ __('Folio') }}:</strong> #{{ $appointment->id }}</p>
+
+    <table>
+        <tr>
+            <th>{{ __('Paciente') }}</th>
+            <td>{{ $appointment->patient->user->name ?? '—' }}</td>
+        </tr>
+        <tr>
+            <th>{{ __('Doctor') }}</th>
+            <td>{{ $appointment->doctor->user->name ?? '—' }}</td>
+        </tr>
+        @if($appointment->doctor->speciality)
+            <tr>
+                <th>{{ __('Especialidad') }}</th>
+                <td>{{ $appointment->doctor->speciality->name }}</td>
+            </tr>
+        @endif
+        <tr>
+            <th>{{ __('Fecha') }}</th>
+            <td>{{ $appointment->date->format('d/m/Y') }}</td>
+        </tr>
+        <tr>
+            <th>{{ __('Horario') }}</th>
+            <td>
+                {{ \Illuminate\Support\Str::substr($appointment->start_time, 0, 5) }}
+                —
+                {{ \Illuminate\Support\Str::substr($appointment->end_time, 0, 5) }}
+            </td>
+        </tr>
+        <tr>
+            <th>{{ __('Estado') }}</th>
+            <td>{{ ucfirst($appointment->status) }}</td>
+        </tr>
+        @if($appointment->reason)
+            <tr>
+                <th>{{ __('Motivo') }}</th>
+                <td>{{ $appointment->reason }}</td>
+            </tr>
+        @endif
+    </table>
+
+    <p class="muted">{{ __('Documento generado automáticamente.') }}</p>
+</body>
+</html>

--- a/routes/console.php
+++ b/routes/console.php
@@ -11,3 +11,6 @@ Artisan::command('inspire', function () {
 // Recordatorios de citas: se ejecuta todos los días a las 08:00 AM
 // Envía WhatsApp a los pacientes con cita programada para el día siguiente
 Schedule::command('appointments:send-reminders')->dailyAt('08:00');
+
+// Reporte diario: correo al administrador y a cada doctor con citas programadas para hoy
+Schedule::command('appointments:send-daily-digest')->dailyAt('08:00');


### PR DESCRIPTION
## Summary
Implements email notifications and PDF generation for the medical appointment system.

## Changes
- Generate PDF receipt on appointment save using barryvdh/laravel-dompdf
- Send email with PDF attachment to patient and doctor on appointment creation
- Added daily digest command `appointments:send-daily-digest` scheduled at 08:00 AM
- Admin receives full daily report with all doctors and patients
- Each doctor receives their own patient list for the day
- Configured Gmail SMTP for email delivery

## How to test
1. Create an appointment and verify emails arrive with PDF attached
2. Run manually: `php artisan appointments:send-daily-digest`
3. Check scheduler: `php artisan schedule:list`

## Related
- Closes ADA 12 - Unidad 3